### PR TITLE
feat: component and edges visibility

### DIFF
--- a/pkgs/app/src/common/diff/array.ts
+++ b/pkgs/app/src/common/diff/array.ts
@@ -1,9 +1,12 @@
+import { diffJson } from 'diff';
+
 import type { DiffObjectsArray } from '../../types/blobs';
 
 export function diffObjectsArray<T>(
   arrayA: T[],
   arrayB: T[],
-  id: keyof T
+  id: keyof T,
+  deep: boolean = false
 ): DiffObjectsArray<T> {
   const idsA = arrayA.map((el) => el[id]);
   const idsB = arrayB.map((el) => el[id]);
@@ -13,8 +16,19 @@ export function diffObjectsArray<T>(
   const modified: T[] = [];
   const unchanged: T[] = [];
 
+  // Find same and deleted
   for (const a of arrayA) {
     if (idsB.includes(a[id])) {
+      if (deep) {
+        const change = diffJson(
+          a as any,
+          arrayB.find((b) => b[id] === a[id]) as any
+        );
+        if (change.length > 1) {
+          modified.push(a);
+          continue;
+        }
+      }
       unchanged.push(a);
       continue;
     }
@@ -22,6 +36,7 @@ export function diffObjectsArray<T>(
     deleted.push(a);
   }
 
+  // Find created
   for (const b of arrayB) {
     if (idsA.includes(b[id])) {
       continue;
@@ -47,6 +62,7 @@ export function diffStringArray<T>(
   const deleted: T[] = [];
   const unchanged: T[] = [];
 
+  // Find same and deleted
   for (const a of arrayA) {
     if (arrayB.includes(a)) {
       unchanged.push(a);
@@ -56,6 +72,7 @@ export function diffStringArray<T>(
     deleted.push(a);
   }
 
+  // Find created
   for (const b of arrayB) {
     if (arrayA.includes(b)) {
       continue;

--- a/pkgs/app/src/common/diff/diffComponent.test.ts
+++ b/pkgs/app/src/common/diff/diffComponent.test.ts
@@ -1,0 +1,272 @@
+import { getApiBlobComponent } from '@specfy/models/src/components/test.helper';
+import { Editor } from '@tiptap/react';
+import { describe, expect, it } from 'vitest';
+
+import { diffComponent } from './diffComponent';
+
+import { createEditorSchema } from '@/components/Editor/extensions';
+
+const editor = new Editor(createEditorSchema());
+
+describe('diffComponent', () => {
+  it('should find no diff when deleted', () => {
+    const a = getApiBlobComponent({ id: 'a', orgId: 'b' });
+    a.deleted = true;
+    const diff = diffComponent(editor, a);
+    expect(diff).toStrictEqual([]);
+  });
+
+  it('should find no diff when nothing has changed', () => {
+    const a = getApiBlobComponent({ id: 'a', orgId: 'b' });
+    a.previous = JSON.parse(JSON.stringify(a.current));
+    const diff = diffComponent(editor, a);
+    expect(diff).toStrictEqual([]);
+  });
+});
+
+describe('edges', () => {
+  it('should find diff added', () => {
+    const a = getApiBlobComponent({ id: 'a', orgId: 'b' });
+    a.previous = JSON.parse(JSON.stringify(a.current));
+    a.current.edges.push({
+      source: 'a',
+      target: 'b',
+      portSource: 'sb',
+      portTarget: 'tb',
+      read: true,
+      write: true,
+      vertices: [],
+    });
+    const diff = diffComponent(editor, a);
+    expect(diff).toHaveLength(1);
+    expect(diff[0]).toMatchObject({
+      key: 'edges',
+      diff: {
+        added: [{ source: 'a' }],
+        deleted: [],
+        changes: 1,
+      },
+    });
+  });
+
+  it('should find diff deleted', () => {
+    const a = getApiBlobComponent({ id: 'a', orgId: 'b' });
+    a.previous = JSON.parse(JSON.stringify(a.current));
+    a.previous!.edges.push({
+      source: 'a',
+      target: 'b',
+      portSource: 'sb',
+      portTarget: 'tb',
+      read: true,
+      write: true,
+      vertices: [],
+    });
+    const diff = diffComponent(editor, a);
+    expect(diff).toHaveLength(1);
+    expect(diff[0]).toMatchObject({
+      key: 'edges',
+      diff: {
+        added: [],
+        deleted: [{ source: 'a' }],
+        changes: 1,
+      },
+    });
+  });
+
+  it('should find diff modified', () => {
+    const a = getApiBlobComponent({ id: 'a', orgId: 'b' });
+    a.current!.edges.push({
+      source: 'a',
+      target: 'b',
+      portSource: 'sb',
+      portTarget: 'tb',
+      read: true,
+      write: true,
+      vertices: [],
+    });
+    a.previous = JSON.parse(JSON.stringify(a.current));
+    a.previous!.edges[0].show = false;
+    const diff = diffComponent(editor, a);
+    expect(diff).toHaveLength(1);
+    expect(diff[0]).toMatchObject({
+      key: 'edges',
+      diff: {
+        added: [],
+        deleted: [],
+        modified: [{ source: 'a' }],
+        changes: 1,
+      },
+    });
+  });
+});
+
+describe('techs', () => {
+  it('should find diff added', () => {
+    const a = getApiBlobComponent({ id: 'a', orgId: 'b' });
+    a.previous = JSON.parse(JSON.stringify(a.current));
+    a.current.techs.push({ id: 'algolia' });
+    const diff = diffComponent(editor, a);
+    expect(diff).toHaveLength(1);
+    expect(diff[0]).toMatchObject({
+      key: 'techs',
+      diff: {
+        added: [{ id: 'algolia' }],
+        deleted: [],
+        changes: 1,
+      },
+    });
+  });
+
+  it('should find diff deleted', () => {
+    const a = getApiBlobComponent({ id: 'a', orgId: 'b' });
+    a.previous = JSON.parse(JSON.stringify(a.current));
+    a.previous!.techs.push({ id: 'algolia' });
+    const diff = diffComponent(editor, a);
+    expect(diff).toHaveLength(1);
+    expect(diff[0]).toMatchObject({
+      key: 'techs',
+      diff: {
+        added: [],
+        deleted: [{ id: 'algolia' }],
+        changes: 1,
+      },
+    });
+  });
+});
+
+describe('tags', () => {
+  it('should find diff added', () => {
+    const a = getApiBlobComponent({ id: 'a', orgId: 'b' });
+    a.previous = JSON.parse(JSON.stringify(a.current));
+    a.current.tags = ['a', 'b'];
+    const diff = diffComponent(editor, a);
+    expect(diff).toHaveLength(1);
+    expect(diff[0]).toMatchObject({
+      key: 'tags',
+      diff: { added: ['a', 'b'], changes: 2 },
+    });
+  });
+
+  it('should find diff deleted', () => {
+    const a = getApiBlobComponent({ id: 'a', orgId: 'b' });
+    a.previous = JSON.parse(JSON.stringify(a.current));
+    a.previous!.tags = ['a', 'b'];
+    const diff = diffComponent(editor, a);
+    expect(diff).toHaveLength(1);
+    expect(diff[0]).toMatchObject({
+      key: 'tags',
+      diff: { deleted: ['a', 'b'], changes: 2 },
+    });
+  });
+  it('should find partial diff', () => {
+    const a = getApiBlobComponent({ id: 'a', orgId: 'b' });
+    a.current.tags = ['a', 'b'];
+    a.previous = JSON.parse(JSON.stringify(a.current));
+    a.previous!.tags = ['c', 'a'];
+    const diff = diffComponent(editor, a);
+    expect(diff).toHaveLength(1);
+    expect(diff[0]).toMatchObject({
+      key: 'tags',
+      diff: { added: ['b'], deleted: ['c'], unchanged: ['a'], changes: 2 },
+    });
+  });
+});
+
+describe('display', () => {
+  it('should find nested diff', () => {
+    const a = getApiBlobComponent({ id: 'a', orgId: 'b' });
+    a.previous = JSON.parse(JSON.stringify(a.current));
+    a.current.display.pos.x = 290;
+    const diff = diffComponent(editor, a);
+    expect(diff).toHaveLength(1);
+    expect(diff[0]).toMatchObject({
+      key: 'display',
+      diff: [
+        {
+          count: 2,
+          value: `{
+  "pos": {
+`,
+        },
+        {
+          added: undefined,
+          count: 1,
+          removed: true,
+          value: `    "x": 0,
+`,
+        },
+        {
+          added: true,
+          count: 1,
+          removed: undefined,
+          value: `    "x": 290,
+`,
+        },
+        {
+          count: 8,
+          value: `    "y": 0
+  },
+  "size": {
+    "height": 40,
+    "width": 130
+  },
+  "zIndex": 1
+}`,
+        },
+      ],
+    });
+  });
+});
+
+describe('inComponent', () => {
+  it('should find diff added', () => {
+    const a = getApiBlobComponent({ id: 'a', orgId: 'b' });
+    a.previous = JSON.parse(JSON.stringify(a.current));
+    a.current.inComponent = { id: 'b' };
+    const diff = diffComponent(editor, a);
+    expect(diff).toHaveLength(1);
+    expect(diff[0]).toMatchObject({
+      key: 'inComponent',
+      diff: 'modified',
+    });
+  });
+
+  it('should find diff deleted', () => {
+    const a = getApiBlobComponent({ id: 'a', orgId: 'b' });
+    a.previous = JSON.parse(JSON.stringify(a.current));
+    a.previous!.inComponent = { id: 'b' };
+    const diff = diffComponent(editor, a);
+    expect(diff).toHaveLength(1);
+    expect(diff[0]).toMatchObject({
+      key: 'inComponent',
+      diff: 'modified',
+    });
+  });
+});
+
+describe('show', () => {
+  it('should find diff from undefined to something', () => {
+    const a = getApiBlobComponent({ id: 'a', orgId: 'b' });
+    a.previous = JSON.parse(JSON.stringify(a.current));
+    a.current.show = false;
+    const diff = diffComponent(editor, a);
+    expect(diff).toHaveLength(1);
+    expect(diff[0]).toMatchObject({
+      key: 'show',
+      diff: 'modified',
+    });
+  });
+
+  it('should find diff deleted', () => {
+    const a = getApiBlobComponent({ id: 'a', orgId: 'b' });
+    a.previous = JSON.parse(JSON.stringify(a.current));
+    a.previous!.show = false;
+    a.current!.show = true;
+    const diff = diffComponent(editor, a);
+    expect(diff).toHaveLength(1);
+    expect(diff[0]).toMatchObject({
+      key: 'show',
+      diff: 'modified',
+    });
+  });
+});

--- a/pkgs/app/src/common/diff/diffComponent.ts
+++ b/pkgs/app/src/common/diff/diffComponent.ts
@@ -1,4 +1,9 @@
-import type { ApiBlobComponent, InComponent } from '@specfy/models';
+import type {
+  ApiBlobComponent,
+  ApiComponent,
+  FlowEdge,
+  InComponent,
+} from '@specfy/models';
 import { IGNORED_COMPONENT_KEYS } from '@specfy/models/src/revisions/constants';
 import type { Editor } from '@tiptap/react';
 import { diffJson, diffWordsWithSpace } from 'diff';
@@ -58,11 +63,35 @@ export function diffComponent(
       });
       continue;
     }
-    if (key === 'edges' || key === 'techs') {
+    if (key === 'edges') {
       const prev = blob.previous?.[key] ? blob.previous[key] : [];
       const value = blob.current[key];
       // TODO: fix as any
-      const change = diffObjectsArray(prev as any, value as any, 'target');
+      const change = diffObjectsArray<FlowEdge>(
+        prev as any,
+        value as any,
+        'target',
+        true
+      );
+      if (change.changes <= 0) {
+        continue;
+      }
+
+      diffs.push({
+        key,
+        diff: change,
+      });
+      continue;
+    }
+    if (key === 'techs') {
+      const prev = blob.previous?.[key] ? blob.previous[key] : [];
+      const value = blob.current[key];
+      // TODO: fix as any
+      const change = diffObjectsArray<ApiComponent['techs'][0]>(
+        prev as any,
+        value as any,
+        'id'
+      );
       if (change.changes <= 0) {
         continue;
       }

--- a/pkgs/app/src/common/store/components.test.ts
+++ b/pkgs/app/src/common/store/components.test.ts
@@ -1,0 +1,292 @@
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+import { type ApiComponent } from '@specfy/models';
+import { describe, it, expect, afterEach } from 'vitest';
+
+import { useComponentsStore as store } from './components';
+import { original } from './original';
+
+afterEach(() => {
+  store.setState({ components: {} });
+  original.store = [];
+});
+
+describe('fill', () => {
+  it('should fill components', () => {
+    const state = store.getState();
+    state.fill([{ id: 'a' } as ApiComponent]);
+    expect(store.getState().components).toStrictEqual({
+      a: {
+        id: 'a',
+      },
+    });
+  });
+
+  it('should override components', () => {
+    const state = store.getState();
+    state.fill([{ id: 'a' } as ApiComponent]);
+    expect(store.getState().components).toStrictEqual({
+      a: { id: 'a' },
+    });
+    state.fill([{ id: 'b' } as ApiComponent]);
+    expect(store.getState().components).toStrictEqual({
+      b: { id: 'b' },
+    });
+  });
+});
+
+describe('create', () => {
+  it('should create component', () => {
+    const state = store.getState();
+    state.create({ id: 'a' } as ApiComponent);
+    expect(store.getState().components).toStrictEqual({
+      a: {
+        id: 'a',
+      },
+    });
+  });
+});
+
+describe('setCurrent', () => {
+  it('should setCurrent component', () => {
+    const state = store.getState();
+    state.create({ id: 'a' } as ApiComponent);
+    state.setCurrent('a');
+    expect(store.getState().current).toBe('a');
+  });
+});
+
+describe('select', () => {
+  it('should select component', () => {
+    const state = store.getState();
+    state.create({ id: 'a' } as ApiComponent);
+    expect(state.select('a')).toStrictEqual({ id: 'a' });
+  });
+
+  it('should not select component', () => {
+    const state = store.getState();
+    expect(state.select('b')).toBeUndefined();
+  });
+});
+
+describe('update', () => {
+  it('should update component', () => {
+    const state = store.getState();
+    state.create({ id: 'a' } as ApiComponent);
+    state.update({ id: 'a', name: 'a' } as ApiComponent);
+    expect(state.select('a')).toStrictEqual({ id: 'a', name: 'a' });
+  });
+
+  it('should not update component', () => {
+    const state = store.getState();
+    state.create({ id: 'a' } as ApiComponent);
+    state.create({ id: 'b' } as ApiComponent);
+    state.update({ id: 'b', name: 'b' } as ApiComponent);
+    expect(state.select('a')).toStrictEqual({ id: 'a' });
+    expect(state.select('b')).toStrictEqual({ id: 'b', name: 'b' });
+  });
+});
+
+describe('updateField', () => {
+  it('should update a field', () => {
+    const state = store.getState();
+    state.create({ id: 'a' } as ApiComponent);
+    state.updateField('a', 'name', 'foobar');
+    expect(state.select('a')).toStrictEqual({ id: 'a', name: 'foobar' });
+  });
+});
+
+describe('revert', () => {
+  it('should revert a component', () => {
+    original.add({ id: 'a' } as ApiComponent);
+
+    const state = store.getState();
+    state.create({ id: 'a' } as ApiComponent);
+    state.updateField('a', 'name', 'foobar');
+    state.revert('a');
+    expect(state.select('a')).toStrictEqual({ id: 'a' });
+  });
+});
+
+describe('revertField', () => {
+  it('should revert a component field', () => {
+    original.add({ id: 'a', name: 'foobar' } as ApiComponent);
+
+    const state = store.getState();
+    state.create({ id: 'a', name: 'foobar' } as ApiComponent);
+    state.updateField('a', 'name', 'barfoo');
+    state.revertField('a', 'name');
+    expect(state.select('a')).toStrictEqual({ id: 'a', name: 'foobar' });
+  });
+});
+
+describe('setVisibility', () => {
+  it('should hide a component', () => {
+    const state = store.getState();
+    state.create({ id: 'a', edges: [], show: true } as unknown as ApiComponent);
+    state.setVisibility('a');
+    expect(state.select('a')).toStrictEqual({
+      id: 'a',
+      show: false,
+      edges: [],
+    });
+  });
+
+  it('should show a component', () => {
+    const state = store.getState();
+    state.create({
+      id: 'a',
+      edges: [],
+      show: false,
+    } as unknown as ApiComponent);
+    state.setVisibility('a');
+    expect(state.select('a')).toStrictEqual({
+      id: 'a',
+      show: true,
+      edges: [],
+    });
+  });
+
+  it.each([true, false])('should show(%o) outgoing/incoming edges', (val) => {
+    const state = store.getState();
+    state.create({
+      id: 'a',
+      edges: [{ target: 'b' }],
+      show: val,
+    } as unknown as ApiComponent);
+    state.create({
+      id: 'b',
+      edges: [{ target: 'a' }],
+      show: true,
+    } as unknown as ApiComponent);
+    state.setVisibility('a');
+    expect(state.select('a')).toStrictEqual({
+      id: 'a',
+      show: !val,
+      edges: [{ target: 'b', show: !val }],
+    });
+    expect(state.select('b')).toStrictEqual({
+      id: 'b',
+      show: true,
+      edges: [{ target: 'a', show: !val }],
+    });
+  });
+});
+
+describe('remove', () => {
+  it('should remove a component', () => {
+    const state = store.getState();
+    state.create({ id: 'a' } as unknown as ApiComponent);
+    state.remove('a');
+    expect(state.select('a')).toBeUndefined();
+  });
+
+  it('should remove incoming edges', () => {
+    const state = store.getState();
+    state.create({ id: 'a' } as unknown as ApiComponent);
+    state.create({
+      id: 'b',
+      inComponent: { id: null },
+      edges: [{ target: 'a' }],
+    } as unknown as ApiComponent);
+    state.remove('a');
+    expect(state.select('b')).toStrictEqual({
+      id: 'b',
+      edges: [],
+      inComponent: { id: null },
+    });
+  });
+
+  it('should remove host and compute new position', () => {
+    const state = store.getState();
+    state.create({
+      id: 'a',
+      inComponent: { id: null },
+      display: { pos: { x: 10, y: 10 } },
+    } as unknown as ApiComponent);
+    state.create({
+      id: 'b',
+      inComponent: { id: 'a' },
+      edges: [],
+      display: { pos: { x: 20, y: 20 } },
+    } as unknown as ApiComponent);
+    const stateBis = store.getState();
+    stateBis.remove('a');
+    expect(JSON.parse(JSON.stringify(state.select('b')))).toStrictEqual({
+      id: 'b',
+      edges: [],
+      display: { pos: { x: 30, y: 30 } },
+      inComponent: { id: null },
+    });
+  });
+});
+
+describe('addEdge', () => {
+  it('should addEdge a component', () => {
+    const state = store.getState();
+    state.create({ id: 'a', edges: [] } as unknown as ApiComponent);
+    state.addEdge({
+      source: 'a',
+      sourceHandle: 'st',
+      target: 'b',
+      targetHandle: 'tt',
+    });
+    const edges = state.select('a')?.edges;
+    expect(edges).toHaveLength(1);
+    expect(edges![0]).toMatchObject({ target: 'b' });
+  });
+
+  it('should dedup edges', () => {
+    const state = store.getState();
+    state.create({
+      id: 'a',
+      edges: [{ target: 'b', portTarget: 'tt' }],
+    } as unknown as ApiComponent);
+    state.addEdge({
+      source: 'a',
+      sourceHandle: 'st',
+      target: 'b',
+      targetHandle: 'tt',
+    });
+    const edges = state.select('a')?.edges;
+    expect(edges).toHaveLength(1);
+    expect(edges![0]).toMatchObject({ target: 'b' });
+  });
+});
+
+describe('updateEdge', () => {
+  it('should updateEdge', () => {
+    const state = store.getState();
+    state.create({
+      id: 'a',
+      edges: [{ target: 'b', portTarget: 'tt' }],
+    } as unknown as ApiComponent);
+
+    state.updateEdge('a', 'b', { portTarget: 'tb' });
+    expect(state.select('a')?.edges[0]).toMatchObject({ portTarget: 'tb' });
+  });
+});
+
+describe('removeEdge', () => {
+  it('should removeEdge', () => {
+    const state = store.getState();
+    state.create({
+      id: 'a',
+      edges: [{ target: 'b', portTarget: 'tt' }],
+    } as unknown as ApiComponent);
+
+    state.removeEdge('a', 'b');
+    expect(state.select('a')?.edges).toHaveLength(0);
+  });
+
+  it('should hide edge with source', () => {
+    const state = store.getState();
+    state.create({
+      id: 'a',
+      edges: [{ target: 'b', portTarget: 'tt', source: 'github' }],
+    } as unknown as ApiComponent);
+
+    state.removeEdge('a', 'b');
+    expect(state.select('a')?.edges).toHaveLength(1);
+    expect(state.select('a')?.edges[0].show).toBe(false);
+  });
+});

--- a/pkgs/app/src/common/store/components.ts
+++ b/pkgs/app/src/common/store/components.ts
@@ -27,7 +27,7 @@ export interface ComponentsState {
   updateEdge: (
     source: string,
     target: string,
-    update: Partial<ApiComponent['edges'][0]>
+    update: Partial<FlowEdge> | ((edge: FlowEdge) => FlowEdge)
   ) => void;
   removeEdge: (source: string, target: string) => void;
 }
@@ -218,7 +218,11 @@ export const useComponentsStore = create<ComponentsState>()((set, get) => ({
             if (edge.target !== target) {
               continue;
             }
-            copy.edges[index] = { ...edge, ...update };
+            if (typeof update === 'function') {
+              copy.edges[index] = update(edge);
+            } else {
+              copy.edges[index] = { ...edge, ...update };
+            }
           }
         }
       })

--- a/pkgs/app/src/components/Component/Details/index.tsx
+++ b/pkgs/app/src/components/Component/Details/index.tsx
@@ -88,6 +88,10 @@ export const ComponentDetails: React.FC<{
     setContains(getAllChilds(components, component.id));
 
     for (const edge of component.edges) {
+      if (edge.show === false) {
+        continue;
+      }
+
       if (edge.read && edge.write) {
         _readwrite.set(edge.target, list.get(edge.target)!);
       } else if (edge.write) {

--- a/pkgs/app/src/components/Component/Line/index.module.scss
+++ b/pkgs/app/src/components/Component/Line/index.module.scss
@@ -69,3 +69,15 @@ $min-height: 34px;
     white-space: nowrap;
   }
 }
+
+.hidden {
+  --btn-color: var(--text2) !important;
+
+  gap: var(--spc-s) !important;
+  padding: var(--spc-m) var(--spc-m) !important;
+  font-size: var(--font-s);
+
+  >svg {
+    width: 1em;
+  }
+}

--- a/pkgs/app/src/components/Editor/AiToolbar/index.tsx
+++ b/pkgs/app/src/components/Editor/AiToolbar/index.tsx
@@ -112,30 +112,28 @@ export const AIToolbar: React.FC<AIToolbarProps> = ({
           </Button>
         </Dropdown.Trigger>
 
-        <Dropdown.Portal>
-          <Dropdown.Content>
-            <Dropdown.Group>
-              {tools.includes('project.description') && (
-                <TooltipFull
-                  msg="Describe the project from all the information Specfy have."
-                  side="right"
-                >
-                  <Dropdown.Item onClick={onGenerate}>
-                    <IconRefresh />
-                    Generate
-                  </Dropdown.Item>
-                </TooltipFull>
-              )}
-              {tools.includes('rewrite') && (
-                <TooltipFull msg="Improve the formulation." side="right">
-                  <Dropdown.Item onClick={onRewrite}>
-                    <IconSparkles /> Rewrite
-                  </Dropdown.Item>
-                </TooltipFull>
-              )}
-            </Dropdown.Group>
-          </Dropdown.Content>
-        </Dropdown.Portal>
+        <Dropdown.Content>
+          <Dropdown.Group>
+            {tools.includes('project.description') && (
+              <TooltipFull
+                msg="Describe the project from all the information Specfy have."
+                side="right"
+              >
+                <Dropdown.Item onClick={onGenerate}>
+                  <IconRefresh />
+                  Generate
+                </Dropdown.Item>
+              </TooltipFull>
+            )}
+            {tools.includes('rewrite') && (
+              <TooltipFull msg="Improve the formulation." side="right">
+                <Dropdown.Item onClick={onRewrite}>
+                  <IconSparkles /> Rewrite
+                </Dropdown.Item>
+              </TooltipFull>
+            )}
+          </Dropdown.Group>
+        </Dropdown.Content>
       </Dropdown.Menu>
     </div>
   );

--- a/pkgs/app/src/components/Flow/CustomNode/index.tsx
+++ b/pkgs/app/src/components/Flow/CustomNode/index.tsx
@@ -87,7 +87,6 @@ const CustomNode: React.FC<NodeProps<NodeData>> = ({
         cls.node,
         selected && cls.selected,
         data.type === 'hosting' && cls.hosting,
-        // isConnecting && cls.isConnecting,
         disableHandle && cls.disableHandle
       )}
     >

--- a/pkgs/app/src/components/Flow/Details/EdgeRelation.tsx
+++ b/pkgs/app/src/components/Flow/Details/EdgeRelation.tsx
@@ -96,42 +96,44 @@ export const EdgeRelation: React.FC<
         </TooltipFull>
       </td>
       {target && <td className={cls.target}>{target.data.name}</td>}
-      <td className={cls.action}>
-        <Dropdown.Menu>
-          <Dropdown.Trigger asChild>
-            <Button size="s" display="ghost">
-              <IconDotsVertical />
-            </Button>
-          </Dropdown.Trigger>
-          <Dropdown.Content>
-            <Dropdown.Item asChild>
-              <TooltipFull
-                msg="Hide or show the component in the Flow"
-                side="right"
-              >
-                <Button display="item" onClick={onVisibility} size="s">
-                  {!edge.hidden ? (
-                    <>
-                      <IconEyeOff /> Hide
-                    </>
-                  ) : (
-                    <>
-                      <IconEye /> Show
-                    </>
-                  )}
-                </Button>
-              </TooltipFull>
-            </Dropdown.Item>
-            {!edge.data?.source && (
+      {!readonly && (
+        <td className={cls.action}>
+          <Dropdown.Menu>
+            <Dropdown.Trigger asChild>
+              <Button size="s" display="ghost">
+                <IconDotsVertical />
+              </Button>
+            </Dropdown.Trigger>
+            <Dropdown.Content>
               <Dropdown.Item asChild>
-                <Button danger display="item" onClick={onRemove} size="s">
-                  <IconTrash /> Remove
-                </Button>
+                <TooltipFull
+                  msg="Hide or show the component in the Flow"
+                  side="right"
+                >
+                  <Button display="item" onClick={onVisibility} size="s">
+                    {!edge.hidden ? (
+                      <>
+                        <IconEyeOff /> Hide
+                      </>
+                    ) : (
+                      <>
+                        <IconEye /> Show
+                      </>
+                    )}
+                  </Button>
+                </TooltipFull>
               </Dropdown.Item>
-            )}
-          </Dropdown.Content>
-        </Dropdown.Menu>
-      </td>
+              {!edge.data?.source && (
+                <Dropdown.Item asChild>
+                  <Button danger display="item" onClick={onRemove} size="s">
+                    <IconTrash /> Remove
+                  </Button>
+                </Dropdown.Item>
+              )}
+            </Dropdown.Content>
+          </Dropdown.Menu>
+        </td>
+      )}
     </tr>
   );
 };

--- a/pkgs/app/src/components/Flow/Details/EdgeRelation.tsx
+++ b/pkgs/app/src/components/Flow/Details/EdgeRelation.tsx
@@ -3,13 +3,21 @@ import {
   IconArrowNarrowLeft,
   IconArrowNarrowRight,
   IconArrowsExchange,
+  IconDotsVertical,
+  IconEye,
+  IconEyeOff,
+  IconTrash,
 } from '@tabler/icons-react';
 import classNames from 'classnames';
 
+import * as Dropdown from '../../../components/Dropdown';
 import { Button } from '../../Form/Button';
 import { TooltipFull } from '../../Tooltip';
+import type { OnEdgesChangeSuper } from '../helpers';
 
-import cls from './index.module.scss';
+import cls from './edge.module.scss';
+
+import { useEdit } from '@/hooks/useEdit';
 
 export interface Relation {
   edge: ComputedEdge;
@@ -20,65 +28,110 @@ export interface Relation {
 export const EdgeRelation: React.FC<
   Relation & {
     readonly: boolean;
-    onDirection: (rel: Relation) => void;
+    onEdgesChange?: OnEdgesChangeSuper;
   }
-> = ({ edge, source, target, readonly, onDirection }) => {
-  const onClick: React.ComponentProps<typeof Button>['onClick'] = (e) => {
-    e.preventDefault();
-    if (readonly) {
-      return;
+> = ({ edge, source, target, readonly, onEdgesChange }) => {
+  const edit = useEdit();
+
+  const onDirection = () => {
+    let read = edge.data!.read;
+    let write = edge.data!.write;
+    if (write && read) {
+      write = false;
+    } else if (!write && read) {
+      read = false;
+      write = true;
+    } else {
+      read = true;
+      write = true;
     }
 
-    onDirection({ edge, source, target });
+    onEdgesChange!([{ type: 'direction', id: edge.id, read, write }]);
+  };
+
+  const onRemove = () => {
+    edit.enable(true);
+    onEdgesChange!([{ type: 'remove', id: edge.id }]);
+  };
+
+  const onVisibility = () => {
+    edit.enable(true);
+    onEdgesChange!([{ type: 'visibility', id: edge.id }]);
   };
 
   return (
-    <tr className={classNames(cls.relation)}>
+    <tr className={classNames(cls.relation, edge.hidden && cls.hidden)}>
       <td className={cls.source}>{source?.data.name}</td>
 
       <td className={cls.to}>
         <TooltipFull msg={!readonly && 'Click to change direction'} side="left">
           <div>
-            {edge.data!.write && edge.data!.read && (
-              <Button
-                className={cls.direction}
-                size="s"
-                display="ghost"
-                onClick={onClick}
-                disabled={readonly}
-              >
-                <IconArrowsExchange />
-                <span className={cls.english}>read/write</span>
-              </Button>
-            )}
-            {!edge.data!.write && edge.data!.read && (
-              <Button
-                className={cls.direction}
-                size="s"
-                display="ghost"
-                onClick={onClick}
-                disabled={readonly}
-              >
-                <IconArrowNarrowLeft />
-                <span className={cls.english}>read</span>
-              </Button>
-            )}
-            {edge.data!.write && !edge.data!.read && (
-              <Button
-                className={cls.direction}
-                size="s"
-                display="ghost"
-                onClick={onClick}
-                disabled={readonly}
-              >
-                <IconArrowNarrowRight />
-                <span className={cls.english}>write</span>
-              </Button>
-            )}
+            <Button
+              className={cls.direction}
+              size="s"
+              display="ghost"
+              onClick={onDirection}
+              disabled={readonly}
+            >
+              {edge.data!.write && edge.data!.read && (
+                <>
+                  <IconArrowsExchange />
+                  <span className={cls.english}>read/write</span>
+                </>
+              )}
+              {!edge.data!.write && edge.data!.read && (
+                <>
+                  <IconArrowNarrowLeft />
+                  <span className={cls.english}>read</span>
+                </>
+              )}
+              {edge.data!.write && !edge.data!.read && (
+                <>
+                  <IconArrowNarrowRight />
+                  <span className={cls.english}>write</span>
+                </>
+              )}
+            </Button>
           </div>
         </TooltipFull>
       </td>
       {target && <td className={cls.target}>{target.data.name}</td>}
+      <td className={cls.action}>
+        <Dropdown.Menu>
+          <Dropdown.Trigger asChild>
+            <Button size="s" display="ghost">
+              <IconDotsVertical />
+            </Button>
+          </Dropdown.Trigger>
+          <Dropdown.Content>
+            <Dropdown.Item asChild>
+              <TooltipFull
+                msg="Hide or show the component in the Flow"
+                side="right"
+              >
+                <Button display="item" onClick={onVisibility} size="s">
+                  {!edge.hidden ? (
+                    <>
+                      <IconEyeOff /> Hide
+                    </>
+                  ) : (
+                    <>
+                      <IconEye /> Show
+                    </>
+                  )}
+                </Button>
+              </TooltipFull>
+            </Dropdown.Item>
+            {!edge.data?.source && (
+              <Dropdown.Item asChild>
+                <Button danger display="item" onClick={onRemove} size="s">
+                  <IconTrash /> Remove
+                </Button>
+              </Dropdown.Item>
+            )}
+          </Dropdown.Content>
+        </Dropdown.Menu>
+      </td>
     </tr>
   );
 };

--- a/pkgs/app/src/components/Flow/Details/edge.module.scss
+++ b/pkgs/app/src/components/Flow/Details/edge.module.scss
@@ -1,0 +1,64 @@
+/* stylelint-disable rule-empty-line-before */
+.relation {
+  height: 35px;
+
+  &:hover {
+    background-color: var(--bg2);
+  }
+
+  &.hidden {
+
+    .source,
+    .target,
+    .to {
+      opacity: 0.3;
+    }
+  }
+}
+
+.target {
+  width: 40%;
+  text-align: right;
+}
+
+.source,
+.target {
+  overflow: hidden;
+  padding: 0 var(--spc-2xl);
+  font-size: var(--font-xs);
+  text-overflow: ellipsis;
+}
+
+.source {
+  width: 35%;
+  text-align: left;
+}
+
+
+.to {
+  position: relative;
+  width: 40px;
+  padding: 0 var(--spc-xl);
+}
+
+.direction {
+  display: flex;
+  justify-content: center;
+
+  margin-top: -10px;
+
+  text-align: center;
+
+  background-color: transparent;
+}
+
+.english {
+  position: absolute;
+  top: 19px;
+  font-size: 9px;
+  color: var(--accent2);
+}
+
+.action {
+  width: 30px;
+}

--- a/pkgs/app/src/components/Flow/Details/index.module.scss
+++ b/pkgs/app/src/components/Flow/Details/index.module.scss
@@ -101,55 +101,7 @@
 // Relation
 .relations {
   table-layout: fixed;
+  border-collapse: collapse;
   width: 100%;
-  margin: 0 0 var(--spc-l) 0
-}
-
-.relation {
-  height: 35px;
-
-  &:hover {
-    background-color: var(--bg2);
-  }
-
-  .target {
-    text-align: right;
-  }
-
-  .source,
-  .target {
-    overflow: hidden;
-    padding: 0 var(--spc-2xl);
-    text-overflow: ellipsis;
-  }
-
-  .source {
-    width: 40%;
-    text-align: left;
-  }
-
-
-  .to {
-    position: relative;
-    width: 40px;
-    padding: 0 var(--spc-xl);
-  }
-
-  .direction {
-    display: flex;
-    justify-content: center;
-
-    margin-top: -10px;
-
-    text-align: center;
-
-    background-color: transparent;
-  }
-
-  .english {
-    position: absolute;
-    top: 19px;
-    font-size: 9px;
-    color: var(--accent2);
-  }
+  margin: 0 0 var(--spc-l) 0;
 }

--- a/pkgs/app/src/components/Flow/Details/index.module.scss
+++ b/pkgs/app/src/components/Flow/Details/index.module.scss
@@ -3,6 +3,7 @@
   z-index: 1;
   right: 0;
 
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
 

--- a/pkgs/app/src/components/Flow/Details/index.tsx
+++ b/pkgs/app/src/components/Flow/Details/index.tsx
@@ -5,14 +5,14 @@ import {
   IconPackageImport,
   IconTrash,
 } from '@tabler/icons-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useDebounce } from 'react-use';
 import { useEdges, useNodes, useOnSelectionChange } from 'reactflow';
 
 import { Button } from '../../Form/Button';
 import { Tag } from '../../Tag';
 import { PreviewNode } from '../CustomNode';
-import type { OnNodesChangeSuper } from '../helpers';
+import type { OnEdgesChangeSuper, OnNodesChangeSuper } from '../helpers';
 
 import type { Relation } from './EdgeRelation';
 import { EdgeRelation } from './EdgeRelation';
@@ -97,8 +97,8 @@ export const FlowDetails: React.FC<{
   readonly: boolean;
   // Events
   onNodesChange?: OnNodesChangeSuper;
-  onRelationChange: (type: 'delete' | 'update', relation: Relation) => void;
-}> = ({ flow, readonly, onNodesChange, onRelationChange }) => {
+  onEdgesChange?: OnEdgesChangeSuper;
+}> = ({ flow, readonly, onNodesChange, onEdgesChange }) => {
   const nodes = useNodes();
   const edges = useEdges<EdgeData>();
 
@@ -194,23 +194,6 @@ export const FlowDetails: React.FC<{
 
     return flow.nodes.find((c) => c.id === currNode.parentNode);
   }, [currNode]);
-
-  const onRelationDirection = useCallback(
-    (rel: Relation) => {
-      if (rel.edge.data!.write && rel.edge.data!.read) {
-        rel.edge.data!.write = false;
-      } else if (!rel.edge.data!.write && rel.edge.data!.read) {
-        rel.edge.data!.read = false;
-        rel.edge.data!.write = true;
-      } else {
-        rel.edge.data!.read = true;
-        rel.edge.data!.write = true;
-      }
-
-      onRelationChange('update', rel);
-    },
-    [nodes]
-  );
 
   const deleteComponent = () => {
     if (onNodesChange) {
@@ -308,7 +291,7 @@ export const FlowDetails: React.FC<{
                           key={rel.edge.id}
                           {...rel}
                           readonly={readonly}
-                          onDirection={onRelationDirection}
+                          onEdgesChange={onEdgesChange}
                         />
                       );
                     })}
@@ -332,7 +315,7 @@ export const FlowDetails: React.FC<{
                           key={rel.edge.id}
                           {...rel}
                           readonly={readonly}
-                          onDirection={onRelationDirection}
+                          onEdgesChange={onEdgesChange}
                         />
                       );
                     })}
@@ -353,7 +336,7 @@ export const FlowDetails: React.FC<{
               <EdgeRelation
                 {...relation}
                 readonly={readonly}
-                onDirection={onRelationDirection}
+                onEdgesChange={onEdgesChange}
               />
             </tbody>
           </table>

--- a/pkgs/app/src/components/Flow/Details/index.tsx
+++ b/pkgs/app/src/components/Flow/Details/index.tsx
@@ -210,6 +210,16 @@ export const FlowDetails: React.FC<{
       onNodesChange([{ id: currNode!.id, type: 'visibility' }]);
     }
   };
+  const deleteEdge = () => {
+    if (onEdgesChange) {
+      onEdgesChange([{ id: relation!.edge.id, type: 'remove' }]);
+    }
+  };
+  const visibilityEdge = () => {
+    if (onEdgesChange) {
+      onEdgesChange([{ id: relation!.edge.id, type: 'visibility' }]);
+    }
+  };
 
   return (
     <div className={cls.composition}>
@@ -330,7 +340,40 @@ export const FlowDetails: React.FC<{
       )}
       {relation && (
         <div className={cls.block}>
-          <div className={cls.title}>Edge</div>
+          <div className={cls.title}>
+            Edge
+            <Flex gap="m">
+              {relation.edge.data!.source && (
+                <TooltipFull
+                  msg={`This edge is managed by: ${relation.edge.data!.source}`}
+                  side="bottom"
+                >
+                  <IconPackageImport />
+                </TooltipFull>
+              )}
+
+              <Flex>
+                {!readonly && (
+                  <Button size="s" display="ghost" onClick={visibilityEdge}>
+                    {relation.edge.hidden ? (
+                      <>
+                        <IconEyeOff />
+                      </>
+                    ) : (
+                      <>
+                        <IconEye />
+                      </>
+                    )}
+                  </Button>
+                )}
+                {!readonly && !relation.edge.data!.source && (
+                  <Button size="s" display="ghost" onClick={deleteEdge}>
+                    <IconTrash />
+                  </Button>
+                )}
+              </Flex>
+            </Flex>
+          </div>
           <table className={cls.relations}>
             <tbody>
               <EdgeRelation

--- a/pkgs/app/src/components/Flow/Details/index.tsx
+++ b/pkgs/app/src/components/Flow/Details/index.tsx
@@ -142,7 +142,6 @@ export const FlowDetails: React.FC<{
   // Useful if we resize or delete it in the flow
   useDebounce(
     () => {
-      console.log('henlo??');
       if (!currNode) {
         return;
       }

--- a/pkgs/app/src/components/Flow/Toolbar/index.tsx
+++ b/pkgs/app/src/components/Flow/Toolbar/index.tsx
@@ -69,7 +69,7 @@ const Readonly: React.FC<{ onClick: () => void }> = ({ onClick }) => {
 
   return (
     <div className={classnames(cls.toolbar, cls.dark)} onClick={handleClick}>
-      <button title="Click to enable edition">
+      <button>
         <Flex gap="m">
           {label}
           <IconLock />

--- a/pkgs/app/src/components/Flow/helpers.tsx
+++ b/pkgs/app/src/components/Flow/helpers.tsx
@@ -117,7 +117,12 @@ export const onNodesChangeProject: (
   return (changes) => {
     for (const change of changes) {
       if (change.type === 'remove') {
-        store.remove(change.id);
+        const comp = store.select(change.id)!;
+        if (comp.source) {
+          store.setVisibility(change.id);
+        } else {
+          store.remove(change.id);
+        }
       } else if (change.type === 'position') {
         if (change.position) {
           const comp = store.select(change.id)!;

--- a/pkgs/app/src/components/Flow/helpers.tsx
+++ b/pkgs/app/src/components/Flow/helpers.tsx
@@ -30,6 +30,10 @@ export type NodeChangeSuper =
   | {
       id: string;
       type: 'ungroup';
+    }
+  | {
+      id: string;
+      type: 'visibility';
     };
 
 export type OnNodesChangeSuper = (changes: NodeChangeSuper[]) => void;
@@ -185,6 +189,8 @@ export const onNodesChangeProject: (
             size: change.dimensions,
           },
         });
+      } else if (change.type === 'visibility') {
+        store.setVisibility(change.id);
       }
     }
   };

--- a/pkgs/app/src/components/Flow/helpers.tsx
+++ b/pkgs/app/src/components/Flow/helpers.tsx
@@ -52,6 +52,16 @@ export type EdgeChangeSuper =
   | {
       type: 'create';
       conn: Connection;
+    }
+  | {
+      type: 'direction';
+      id: string;
+      read: boolean;
+      write: boolean;
+    }
+  | {
+      type: 'visibility';
+      id: string;
     };
 export type OnEdgesChangeSuper = (changes: EdgeChangeSuper[]) => void;
 
@@ -111,6 +121,9 @@ export function highlightNode({
   return { nodes: upNodes, edges: upEdges };
 }
 
+/**
+ * Central function to handle all node changes (in a project).
+ */
 export const onNodesChangeProject: (
   store: ComponentsState
 ) => OnNodesChangeSuper = (store) => {
@@ -196,6 +209,59 @@ export const onNodesChangeProject: (
         });
       } else if (change.type === 'visibility') {
         store.setVisibility(change.id);
+      }
+    }
+  };
+};
+
+/**
+ * Central function to handle all edge changes (in a project).
+ */
+export const onEdgesChangeProject: (
+  store: ComponentsState
+) => OnEdgesChangeSuper = (store) => {
+  return (changes) => {
+    for (const change of changes) {
+      switch (change.type) {
+        case 'remove': {
+          const [source, target] = change.id.split('->');
+          store.removeEdge(source, target);
+          break;
+        }
+
+        case 'changeTarget': {
+          store.updateEdge(change.source, change.oldTarget, {
+            portSource: change.newSourceHandle as any,
+            target: change.newTarget,
+            portTarget: change.newTargetHandle as any,
+          });
+          break;
+        }
+
+        case 'create': {
+          store.addEdge(change.conn);
+          break;
+        }
+
+        case 'direction': {
+          const [source, target] = change.id.split('->');
+          store.updateEdge(source, target, {
+            write: change.write,
+            read: change.read,
+          });
+          break;
+        }
+
+        case 'visibility': {
+          const [source, target] = change.id.split('->');
+          store.updateEdge(source, target, (st) => {
+            st.show =
+              st.show === true || typeof st.show === 'undefined' ? false : true;
+            console.log('changing visibility', source, target, st.show);
+            return st;
+          });
+          break;
+        }
       }
     }
   };

--- a/pkgs/app/src/components/Flow/index.tsx
+++ b/pkgs/app/src/components/Flow/index.tsx
@@ -13,7 +13,13 @@ import {
   updateEdge,
   SelectionMode,
 } from 'reactflow';
-import type { NodeTypes, ReactFlowInstance, ReactFlowProps } from 'reactflow';
+import type {
+  NodeTypes,
+  OnEdgesChange,
+  OnNodesChange,
+  ReactFlowInstance,
+  ReactFlowProps,
+} from 'reactflow';
 
 import 'reactflow/dist/style.css';
 import CustomNode from './CustomNode';
@@ -96,7 +102,9 @@ export const Flow: React.FC<{
           find.targetHandle = edge.targetHandle;
           find.sourceHandle = edge.sourceHandle;
           find.data = edge.data;
+          find.hidden = edge.hidden;
         }
+
         find.deletable = !readonly && deletable;
         find.updatable = !readonly && connectable;
 
@@ -115,6 +123,7 @@ export const Flow: React.FC<{
           find.extent = node.extent;
           find.position = node.position;
           find.data = node.data;
+          find.hidden = node.hidden;
         }
         find.deletable = !readonly && deletable;
         find.draggable = !readonly;
@@ -126,6 +135,26 @@ export const Flow: React.FC<{
       });
     });
   }, [readonly, flow]);
+
+  // --- Updates changes
+  const middlewareNodesChange: OnNodesChange = (changes) => {
+    if (changes[0].type !== 'remove') {
+      // dimensions/position/select needs to be applied right away to avoid flickering
+      handleNodesChange(changes);
+    }
+    if (onNodesChange) {
+      onNodesChange(changes);
+    }
+  };
+  const middlewareEdgesChange: OnEdgesChange = (changes) => {
+    if (changes[0].type !== 'remove') {
+      // dimensions/position/select needs to be applied right away to avoid flickering
+      handleEdgesChange(changes);
+    }
+    if (onEdgesChange) {
+      onEdgesChange(changes);
+    }
+  };
 
   // --- Highlighting
   const setHighlightNode = (id: string) => {
@@ -458,15 +487,8 @@ export const Flow: React.FC<{
         onNodeDrag={onNodeDrag}
         onNodeDragStop={onNodeDragStop}
         // Global
-        onNodesChange={(changes) => {
-          // Useful for resize
-          handleNodesChange(changes);
-          if (onNodesChange) onNodesChange(changes);
-        }}
-        onEdgesChange={(changes) => {
-          handleEdgesChange(changes);
-          if (onEdgesChange) onEdgesChange(changes);
-        }}
+        onNodesChange={middlewareNodesChange}
+        onEdgesChange={middlewareEdgesChange}
       >
         <Background id="1" gap={10} color="#c5c7ca" />
         <Background

--- a/pkgs/app/src/components/Org/Header/index.tsx
+++ b/pkgs/app/src/components/Org/Header/index.tsx
@@ -68,36 +68,34 @@ export const OrgSwitcher: React.FC = () => {
             <IconChevronDown />
           </button>
         </Dropdown.Trigger>
-        <Dropdown.Portal>
-          <Dropdown.Content>
-            <Dropdown.Group>
-              {orgsQuery.data?.data.map((org) => {
-                return (
-                  <Dropdown.Item key={org.id} asChild>
-                    <Link
-                      to={`/${org.id}`}
-                      className={classNames(
-                        cls.org,
-                        current.id === org.id && cls.current
-                      )}
-                    >
-                      <AvatarAuto org={org} /> {org.name}
-                    </Link>
-                  </Dropdown.Item>
-                );
-              })}
-            </Dropdown.Group>
-            <Dropdown.Separator />
-            <Dropdown.Group>
-              <Dropdown.Item asChild>
-                <Link to="/organizations/new" className={cls.org}>
-                  <IconPlus size="1em" />
-                  Create organization
-                </Link>
-              </Dropdown.Item>
-            </Dropdown.Group>
-          </Dropdown.Content>
-        </Dropdown.Portal>
+        <Dropdown.Content>
+          <Dropdown.Group>
+            {orgsQuery.data?.data.map((org) => {
+              return (
+                <Dropdown.Item key={org.id} asChild>
+                  <Link
+                    to={`/${org.id}`}
+                    className={classNames(
+                      cls.org,
+                      current.id === org.id && cls.current
+                    )}
+                  >
+                    <AvatarAuto org={org} /> {org.name}
+                  </Link>
+                </Dropdown.Item>
+              );
+            })}
+          </Dropdown.Group>
+          <Dropdown.Separator />
+          <Dropdown.Group>
+            <Dropdown.Item asChild>
+              <Link to="/organizations/new" className={cls.org}>
+                <IconPlus size="1em" />
+                Create organization
+              </Link>
+            </Dropdown.Item>
+          </Dropdown.Group>
+        </Dropdown.Content>
       </Dropdown.Menu>
     </div>
   );

--- a/pkgs/app/src/components/Project/Header/index.tsx
+++ b/pkgs/app/src/components/Project/Header/index.tsx
@@ -57,39 +57,34 @@ export const ProjectSwitcher: React.FC = () => {
             <IconChevronDown />
           </button>
         </Dropdown.Trigger>
-        <Dropdown.Portal>
-          <Dropdown.Content>
-            <Dropdown.Group className={cls.content}>
-              {projects.map((item) => {
-                return (
-                  <Dropdown.Item key={item.id} asChild>
-                    <Link
-                      to={`/${item.orgId}/${item.slug}${paths}`}
-                      className={classNames(
-                        cls.org,
-                        project.id === item.id && cls.current
-                      )}
-                    >
-                      <AvatarAuto name={item.name} shape="square" /> {item.name}
-                    </Link>
-                  </Dropdown.Item>
-                );
-              })}
-            </Dropdown.Group>
-            <Dropdown.Separator />
-            <Dropdown.Group>
-              <Dropdown.Item asChild>
-                <Link
-                  to={`/${project.orgId}/_/project/new`}
-                  className={cls.org}
-                >
-                  <IconPlus size="1em" />
-                  Create project
-                </Link>
-              </Dropdown.Item>
-            </Dropdown.Group>
-          </Dropdown.Content>
-        </Dropdown.Portal>
+        <Dropdown.Content>
+          <Dropdown.Group className={cls.content}>
+            {projects.map((item) => {
+              return (
+                <Dropdown.Item key={item.id} asChild>
+                  <Link
+                    to={`/${item.orgId}/${item.slug}${paths}`}
+                    className={classNames(
+                      cls.org,
+                      project.id === item.id && cls.current
+                    )}
+                  >
+                    <AvatarAuto name={item.name} shape="square" /> {item.name}
+                  </Link>
+                </Dropdown.Item>
+              );
+            })}
+          </Dropdown.Group>
+          <Dropdown.Separator />
+          <Dropdown.Group>
+            <Dropdown.Item asChild>
+              <Link to={`/${project.orgId}/_/project/new`} className={cls.org}>
+                <IconPlus size="1em" />
+                Create project
+              </Link>
+            </Dropdown.Item>
+          </Dropdown.Group>
+        </Dropdown.Content>
       </Dropdown.Menu>
     </div>
   );

--- a/pkgs/app/src/components/Revision/DiffCard/CardComponent.tsx
+++ b/pkgs/app/src/components/Revision/DiffCard/CardComponent.tsx
@@ -346,15 +346,16 @@ export const DiffCardComponent: React.FC<{
             <div key={d.key} className={classnames(cls.spaced)}>
               <h4>Host</h4>
               <Flex style={{ margin: '10px 0 0 0' }} gap="2xl">
-                {oldComp && (
-                  <Flex gap="l" className={cls.removed}>
+                <Flex gap="l" className={cls.removed}>
+                  {oldComp && (
                     <ComponentItem
                       className={cls.item}
                       comp={oldComp}
                       params={params}
                     />
-                  </Flex>
-                )}
+                  )}
+                  no host
+                </Flex>
                 <div>
                   <IconArrowRight />
                 </div>

--- a/pkgs/app/src/components/Revision/DiffCard/CardComponent.tsx
+++ b/pkgs/app/src/components/Revision/DiffCard/CardComponent.tsx
@@ -288,7 +288,7 @@ export const DiffCardComponent: React.FC<{
           const change = d.diff as DiffObjectsArray<ApiComponent['edges'][0]>;
           return (
             <div key={d.key} className={classnames(cls.line)}>
-              <h4>Data</h4>
+              <h4>Connections</h4>
               {change.added.map((edge) => {
                 const comp = getComponent(edge.target);
                 return (
@@ -326,7 +326,10 @@ export const DiffCardComponent: React.FC<{
                       className={cls.item}
                       comp={comp}
                       params={params}
-                    />
+                    />{' '}
+                    <span className={classnames(cls.added, cls.inline)}>
+                      (display)
+                    </span>
                   </div>
                 );
               })}

--- a/pkgs/app/src/components/Revision/DiffCard/Flow/index.module.scss
+++ b/pkgs/app/src/components/Revision/DiffCard/Flow/index.module.scss
@@ -1,7 +1,12 @@
-.nodeCreated,
-.nodeModified {
+/* stylelint-disable selector-class-pattern */
+.nodeCreated {
   border-radius: 6px;
   box-shadow: 0 0 2px 0 var(--modified1);
+}
+
+.nodeModified {
+  border-radius: 6px;
+  box-shadow: 0 0 2px 0 var(--amber-10);
 }
 
 .nodeDeleted {
@@ -9,11 +14,8 @@
   box-shadow: 0 0 2px 0 var(--decline2);
 }
 
-.edgeCreated,
-.edgeModified {
+.edgeCreated {
   :global {
-
-    /* stylelint-disable-next-line selector-class-pattern */
     .react-flow__edge-path {
       stroke: var(--modified1);
       stroke-dasharray: 2;
@@ -22,10 +24,18 @@
   }
 }
 
+.edgeModified {
+  :global {
+    .react-flow__edge-path {
+      stroke: var(--amber-10);
+      stroke-dasharray: 2;
+      stroke-width: 2px;
+    }
+  }
+}
+
 .edgeDeleted {
   :global {
-
-    /* stylelint-disable-next-line selector-class-pattern */
     .react-flow__edge-path {
       stroke: var(--decline2);
       stroke-dasharray: 2;

--- a/pkgs/app/src/components/Revision/DiffCard/Flow/index.tsx
+++ b/pkgs/app/src/components/Revision/DiffCard/Flow/index.tsx
@@ -29,11 +29,13 @@ const fieldsNode: Array<keyof ComputedNode> = [
   'width',
   'height',
   'parentNode',
+  'hidden',
 ];
 const fieldsEdge: Array<keyof ComputedEdge> = [
   'data',
   'sourceHandle',
   'targetHandle',
+  'hidden',
 ];
 
 export const DiffFlow: React.FC<{
@@ -50,7 +52,7 @@ export const DiffFlow: React.FC<{
     const edgesChanged = new Map<string, 'created' | 'modified'>();
     const edgesDeleted: ComputedEdge[] = [];
 
-    // Diff nodes
+    // ---- Diff nodes
     for (const node of prev.nodes) {
       const newNode = next.nodes.find((n) => n.id === node.id);
       if (!newNode) {
@@ -69,7 +71,7 @@ export const DiffFlow: React.FC<{
       nodesChanged.set(node.id, 'created');
     }
 
-    // Diff edges
+    // ---- Diff edges
     for (const edge of prev.edges) {
       const newEdge = next.edges.find((n) => n.id === edge.id);
       if (!newEdge) {
@@ -101,6 +103,7 @@ export const DiffFlow: React.FC<{
           change === 'modified' && cls.nodeModified,
           !change && cls.unmodified
         );
+        node.hidden = change ? false : node.hidden;
 
         return node;
       });
@@ -131,6 +134,7 @@ export const DiffFlow: React.FC<{
           change === 'modified' && cls.edgeModified,
           !change && cls.unmodified
         );
+        edge.hidden = change ? false : edge.hidden;
         return edge;
       });
 

--- a/pkgs/app/src/components/Revision/MainCard/index.tsx
+++ b/pkgs/app/src/components/Revision/MainCard/index.tsx
@@ -171,50 +171,48 @@ export const RevisionMainCard: React.FC<{ rev: ApiRevision }> = ({ rev }) => {
                       <IconDotsVertical />
                     </Button>
                   </Dropdown.Trigger>
-                  <Dropdown.Portal>
-                    <Dropdown.Content>
-                      <Dropdown.Group>
-                        {!rev.locked ? (
-                          <Dropdown.Item asChild>
-                            <Button
-                              display="item"
-                              onClick={() => onMenuClick('lock')}
-                            >
-                              <IconLock /> Lock
-                            </Button>
-                          </Dropdown.Item>
-                        ) : (
-                          <Dropdown.Item asChild>
-                            <Button
-                              display="item"
-                              onClick={() => onMenuClick('unlock')}
-                            >
-                              <IconLockAccessOff /> Unlock
-                            </Button>
-                          </Dropdown.Item>
-                        )}
-                        {!rev.closedAt ? (
-                          <Dropdown.Item asChild>
-                            <Button
-                              display="item"
-                              onClick={() => onMenuClick('close')}
-                            >
-                              <IconGitPullRequestClosed /> Close
-                            </Button>
-                          </Dropdown.Item>
-                        ) : (
-                          <Dropdown.Item asChild>
-                            <Button
-                              display="item"
-                              onClick={() => onMenuClick('reopen')}
-                            >
-                              <IconGitPullRequestClosed /> Open
-                            </Button>
-                          </Dropdown.Item>
-                        )}
-                      </Dropdown.Group>
-                    </Dropdown.Content>
-                  </Dropdown.Portal>
+                  <Dropdown.Content>
+                    <Dropdown.Group>
+                      {!rev.locked ? (
+                        <Dropdown.Item asChild>
+                          <Button
+                            display="item"
+                            onClick={() => onMenuClick('lock')}
+                          >
+                            <IconLock /> Lock
+                          </Button>
+                        </Dropdown.Item>
+                      ) : (
+                        <Dropdown.Item asChild>
+                          <Button
+                            display="item"
+                            onClick={() => onMenuClick('unlock')}
+                          >
+                            <IconLockAccessOff /> Unlock
+                          </Button>
+                        </Dropdown.Item>
+                      )}
+                      {!rev.closedAt ? (
+                        <Dropdown.Item asChild>
+                          <Button
+                            display="item"
+                            onClick={() => onMenuClick('close')}
+                          >
+                            <IconGitPullRequestClosed /> Close
+                          </Button>
+                        </Dropdown.Item>
+                      ) : (
+                        <Dropdown.Item asChild>
+                          <Button
+                            display="item"
+                            onClick={() => onMenuClick('reopen')}
+                          >
+                            <IconGitPullRequestClosed /> Open
+                          </Button>
+                        </Dropdown.Item>
+                      )}
+                    </Dropdown.Group>
+                  </Dropdown.Content>
                 </Dropdown.Menu>
               )}
             </Flex>

--- a/pkgs/app/src/components/Sidebar/Header/index.tsx
+++ b/pkgs/app/src/components/Sidebar/Header/index.tsx
@@ -37,35 +37,33 @@ const User: React.FC = () => {
             <AvatarAuto user={user!} />
           </button>
         </Dropdown.Trigger>
-        <Dropdown.Portal>
-          <Dropdown.Content>
-            <div className={cls.userDropdown}>
-              <strong>{user!.name}</strong>
-              <Subdued>{user!.email}</Subdued>
-            </div>
+        <Dropdown.Content>
+          <div className={cls.userDropdown}>
+            <strong>{user!.name}</strong>
+            <Subdued>{user!.email}</Subdued>
+          </div>
 
-            <Dropdown.Separator />
-            <Dropdown.Group>
-              <Dropdown.Item asChild>
-                <Link to="/account/">
-                  <IconSettings />
-                  <div>Settings</div>
-                </Link>
-              </Dropdown.Item>
-            </Dropdown.Group>
+          <Dropdown.Separator />
+          <Dropdown.Group>
+            <Dropdown.Item asChild>
+              <Link to="/account/">
+                <IconSettings />
+                <div>Settings</div>
+              </Link>
+            </Dropdown.Item>
+          </Dropdown.Group>
 
-            <Dropdown.Separator />
+          <Dropdown.Separator />
 
-            <Dropdown.Group>
-              <Dropdown.Item asChild>
-                <button onClick={handleLogout}>
-                  <IconLogout />
-                  <div>Logout</div>
-                </button>
-              </Dropdown.Item>
-            </Dropdown.Group>
-          </Dropdown.Content>
-        </Dropdown.Portal>
+          <Dropdown.Group>
+            <Dropdown.Item asChild>
+              <button onClick={handleLogout}>
+                <IconLogout />
+                <div>Logout</div>
+              </button>
+            </Dropdown.Item>
+          </Dropdown.Group>
+        </Dropdown.Content>
       </Dropdown.Menu>
     </div>
   );

--- a/pkgs/app/src/hooks/useEdit.tsx
+++ b/pkgs/app/src/hooks/useEdit.tsx
@@ -20,8 +20,10 @@ export const EditProvider: React.FC<{ children: React.ReactNode }> = ({
     const tmp: EditContextInterface = {
       isEditing: enabled,
       enable: (val) => {
-        setPrev(enabled);
-        setEnabled(val);
+        if (val !== enabled) {
+          setPrev(enabled);
+          setEnabled(val);
+        }
       },
       prev: () => {
         return prev;

--- a/pkgs/app/src/views/Org/Flow/index.tsx
+++ b/pkgs/app/src/views/Org/Flow/index.tsx
@@ -120,11 +120,7 @@ export const OrgFlow: React.FC<{ org: ApiOrg; params: RouteOrg }> = ({
               connectable={true}
             />
 
-            <FlowDetails
-              readonly={true}
-              flow={flow}
-              onRelationChange={() => null}
-            />
+            <FlowDetails readonly={true} flow={flow} />
             {canEdit && (
               <Toolbar left top visible>
                 {!editing && (

--- a/pkgs/app/src/views/Org/Settings/Team/Pending/index.tsx
+++ b/pkgs/app/src/views/Org/Settings/Team/Pending/index.tsx
@@ -43,23 +43,21 @@ const Row: React.FC<{
                 <IconDotsVertical />
               </Button>
             </Dropdown.Trigger>
-            <Dropdown.Portal>
-              <Dropdown.Content>
-                <Dropdown.Group>
-                  <Dropdown.Item asChild>
-                    <Button
-                      danger
-                      display="item"
-                      block
-                      onClick={() => onRemove(item)}
-                      size="s"
-                    >
-                      <IconTrash /> Remove
-                    </Button>
-                  </Dropdown.Item>
-                </Dropdown.Group>
-              </Dropdown.Content>
-            </Dropdown.Portal>
+            <Dropdown.Content>
+              <Dropdown.Group>
+                <Dropdown.Item asChild>
+                  <Button
+                    danger
+                    display="item"
+                    block
+                    onClick={() => onRemove(item)}
+                    size="s"
+                  >
+                    <IconTrash /> Remove
+                  </Button>
+                </Dropdown.Item>
+              </Dropdown.Group>
+            </Dropdown.Content>
           </Dropdown.Menu>
         </div>
       </Flex>

--- a/pkgs/app/src/views/Project/Component/index.module.scss
+++ b/pkgs/app/src/views/Project/Component/index.module.scss
@@ -7,27 +7,22 @@
 }
 
 .tagType {
+  font-size: var(--font-s);
   color: var(--text3);
-  background-color: #fff;
-  border: 1px solid var(--border2) !important;
 
   &.service {
     color: var(--service);
-    border-color: var(--service) !important;
   }
 
   &.saas {
     color: var(--plum-9);
-    border-color: var(--plum-9) !important;
   }
 
   &.project {
     color: var(--amber-10);
-    border-color: var(--amber-9) !important;
   }
 
   &.hosting {
     color: var(--indigo-9);
-    border-color: var(--indigo-9) !important;
   }
 }

--- a/pkgs/app/src/views/Project/Component/index.tsx
+++ b/pkgs/app/src/views/Project/Component/index.tsx
@@ -34,7 +34,6 @@ import { onNodesChangeProject } from '../../../components/Flow/helpers';
 import { Button } from '../../../components/Form/Button';
 import { FakeInput } from '../../../components/Form/FakeInput';
 import { NotFound } from '../../../components/NotFound';
-import { Tag } from '../../../components/Tag';
 import { TooltipFull } from '../../../components/Tooltip';
 import { UpdatedAt } from '../../../components/UpdatedAt';
 import { useAuth } from '../../../hooks/useAuth';
@@ -269,16 +268,16 @@ export const ComponentView: React.FC<{
             </Flex>
           </Flex>
           <Flex gap="m" align="flex-start">
-            <UpdatedAt time={comp.updatedAt} />
-            <Tag
-              variant="border"
+            <div
               className={classnames(
                 cls.tagType,
                 comp.type in cls && cls[comp.type as keyof typeof cls]
               )}
             >
               {internalTypeToText[comp.type]}
-            </Tag>
+            </div>
+            ·
+            <UpdatedAt time={comp.updatedAt} />
           </Flex>
 
           {!isEditing && comp.description && (

--- a/pkgs/app/src/views/Project/Component/index.tsx
+++ b/pkgs/app/src/views/Project/Component/index.tsx
@@ -5,6 +5,8 @@ import {
   IconDotsVertical,
   IconTrash,
   IconPackageImport,
+  IconEyeOff,
+  IconEye,
 } from '@tabler/icons-react';
 import classnames from 'classnames';
 import type React from 'react';
@@ -113,6 +115,16 @@ export const ComponentView: React.FC<{
     onNodesChangeProject(storeComponents)(changes);
   };
 
+  const onVisibility = (show: boolean) => {
+    edit.enable(true);
+    // storeComponents.updateField(comp!.id, 'show', show);
+    onNodesChange([{ type: 'visibility', id: comp!.id }]);
+    toast.add({
+      title: show ? 'Component is visible' : 'Component will be hidden',
+      status: 'success',
+    });
+  };
+
   if (loading) {
     return <Loading />;
   }
@@ -186,6 +198,14 @@ export const ComponentView: React.FC<{
             </Flex>
             <Flex align="center" gap="m">
               <Flex gap="l">
+                {!comp.show && (
+                  <TooltipFull
+                    msg={`This component is hidden in the Flow`}
+                    side="bottom"
+                  >
+                    <IconEyeOff />
+                  </TooltipFull>
+                )}
                 {comp.source && (
                   <TooltipFull
                     msg={`This component is managed by: ${comp.source}`}
@@ -194,15 +214,6 @@ export const ComponentView: React.FC<{
                     <IconPackageImport />
                   </TooltipFull>
                 )}
-                <Tag
-                  variant="border"
-                  className={classnames(
-                    cls.tagType,
-                    comp.type in cls && cls[comp.type as keyof typeof cls]
-                  )}
-                >
-                  {internalTypeToText[comp.type]}
-                </Tag>
               </Flex>
               {canEdit && (
                 <div>
@@ -216,16 +227,39 @@ export const ComponentView: React.FC<{
                       <Dropdown.Content>
                         <Dropdown.Group>
                           <Dropdown.Item asChild>
-                            <Button
-                              danger
-                              display="item"
-                              block
-                              onClick={() => onRemove()}
-                              size="s"
+                            <TooltipFull
+                              msg="Hide or show the component in the Flow"
+                              side="right"
                             >
-                              <IconTrash /> Remove
-                            </Button>
+                              <Button
+                                display="item"
+                                onClick={() => onVisibility(!comp.show)}
+                                size="s"
+                              >
+                                {comp.show ? (
+                                  <>
+                                    <IconEyeOff /> Hide
+                                  </>
+                                ) : (
+                                  <>
+                                    <IconEye /> Show
+                                  </>
+                                )}
+                              </Button>
+                            </TooltipFull>
                           </Dropdown.Item>
+                          {!comp.source && (
+                            <Dropdown.Item asChild>
+                              <Button
+                                danger
+                                display="item"
+                                onClick={() => onRemove()}
+                                size="s"
+                              >
+                                <IconTrash /> Remove
+                              </Button>
+                            </Dropdown.Item>
+                          )}
                         </Dropdown.Group>
                       </Dropdown.Content>
                     </Dropdown.Portal>
@@ -234,7 +268,18 @@ export const ComponentView: React.FC<{
               )}
             </Flex>
           </Flex>
-          <UpdatedAt time={comp.updatedAt} />
+          <Flex gap="m" align="flex-start">
+            <UpdatedAt time={comp.updatedAt} />
+            <Tag
+              variant="border"
+              className={classnames(
+                cls.tagType,
+                comp.type in cls && cls[comp.type as keyof typeof cls]
+              )}
+            >
+              {internalTypeToText[comp.type]}
+            </Tag>
+          </Flex>
 
           {!isEditing && comp.description && (
             <Editable padded>

--- a/pkgs/app/src/views/Project/Component/index.tsx
+++ b/pkgs/app/src/views/Project/Component/index.tsx
@@ -114,12 +114,12 @@ export const ComponentView: React.FC<{
     onNodesChangeProject(storeComponents)(changes);
   };
 
-  const onVisibility = (show: boolean) => {
+  const onVisibility = () => {
     edit.enable(true);
     // storeComponents.updateField(comp!.id, 'show', show);
     onNodesChange([{ type: 'visibility', id: comp!.id }]);
     toast.add({
-      title: show ? 'Component is visible' : 'Component will be hidden',
+      title: !comp!.show ? 'Component is visible' : 'Component will be hidden',
       status: 'success',
     });
   };
@@ -222,46 +222,44 @@ export const ComponentView: React.FC<{
                         <IconDotsVertical />
                       </Button>
                     </Dropdown.Trigger>
-                    <Dropdown.Portal>
-                      <Dropdown.Content>
-                        <Dropdown.Group>
-                          <Dropdown.Item asChild>
-                            <TooltipFull
-                              msg="Hide or show the component in the Flow"
-                              side="right"
+                    <Dropdown.Content>
+                      <Dropdown.Group>
+                        <Dropdown.Item asChild>
+                          <TooltipFull
+                            msg="Hide or show the component in the Flow"
+                            side="right"
+                          >
+                            <Button
+                              display="item"
+                              onClick={onVisibility}
+                              size="s"
                             >
-                              <Button
-                                display="item"
-                                onClick={() => onVisibility(!comp.show)}
-                                size="s"
-                              >
-                                {comp.show ? (
-                                  <>
-                                    <IconEyeOff /> Hide
-                                  </>
-                                ) : (
-                                  <>
-                                    <IconEye /> Show
-                                  </>
-                                )}
-                              </Button>
-                            </TooltipFull>
+                              {comp.show ? (
+                                <>
+                                  <IconEyeOff /> Hide
+                                </>
+                              ) : (
+                                <>
+                                  <IconEye /> Show
+                                </>
+                              )}
+                            </Button>
+                          </TooltipFull>
+                        </Dropdown.Item>
+                        {!comp.source && (
+                          <Dropdown.Item asChild>
+                            <Button
+                              danger
+                              display="item"
+                              onClick={onRemove}
+                              size="s"
+                            >
+                              <IconTrash /> Remove
+                            </Button>
                           </Dropdown.Item>
-                          {!comp.source && (
-                            <Dropdown.Item asChild>
-                              <Button
-                                danger
-                                display="item"
-                                onClick={() => onRemove()}
-                                size="s"
-                              >
-                                <IconTrash /> Remove
-                              </Button>
-                            </Dropdown.Item>
-                          )}
-                        </Dropdown.Group>
-                      </Dropdown.Content>
-                    </Dropdown.Portal>
+                        )}
+                      </Dropdown.Group>
+                    </Dropdown.Content>
                   </Dropdown.Menu>
                 </div>
               )}

--- a/pkgs/app/src/views/Project/Flow/index.tsx
+++ b/pkgs/app/src/views/Project/Flow/index.tsx
@@ -10,7 +10,10 @@ import type {
   OnEdgesChangeSuper,
   OnNodesChangeSuper,
 } from '../../../components/Flow/helpers';
-import { onNodesChangeProject } from '../../../components/Flow/helpers';
+import {
+  onEdgesChangeProject,
+  onNodesChangeProject,
+} from '../../../components/Flow/helpers';
 import { Loading } from '../../../components/Loading';
 import { useEdit } from '../../../hooks/useEdit';
 import type { RouteProject } from '../../../types/routes';
@@ -54,36 +57,9 @@ export const ProjectFlow: React.FC<{
     [components]
   );
   const onEdgesChange = useCallback<OnEdgesChangeSuper>(
-    (changes) => {
-      for (const change of changes) {
-        if (change.type === 'remove') {
-          const [source, target] = change.id.split('->');
-          storeComponents.removeEdge(source, target);
-        } else if (change.type === 'changeTarget') {
-          storeComponents.updateEdge(change.source, change.oldTarget, {
-            portSource: change.newSourceHandle as any,
-            target: change.newTarget,
-            portTarget: change.newTargetHandle as any,
-          });
-        } else if (change.type === 'create') {
-          storeComponents.addEdge(change.conn);
-        }
-      }
-    },
+    (changes) => onEdgesChangeProject(storeComponents)(changes),
     [components]
   );
-
-  // TODO: replace this with onEdgesChange
-  const onRelationChange: React.ComponentProps<
-    typeof FlowDetails
-  >['onRelationChange'] = useCallback((type, rel) => {
-    if (type === 'update') {
-      storeComponents.updateEdge(rel.edge.source, rel.edge.target, {
-        write: rel.edge.data!.write,
-        read: rel.edge.data!.read,
-      });
-    }
-  }, []);
 
   const onCreateNode: React.ComponentProps<typeof Flow>['onCreateNode'] = (
     type,
@@ -126,7 +102,7 @@ export const ProjectFlow: React.FC<{
           flow={flow}
           readonly={!isEditing}
           onNodesChange={onNodesChange}
-          onRelationChange={onRelationChange}
+          onEdgesChange={onEdgesChange}
         />
         {isEditing && (
           <Toolbar left center visible>

--- a/pkgs/core/src/validators/prosemirror.ts
+++ b/pkgs/core/src/validators/prosemirror.ts
@@ -49,7 +49,10 @@ const blockHardBreak = z
       .strict()
       .partial({ uid: true }),
   })
-  .strict();
+  .strict()
+  .partial({
+    attrs: true,
+  });
 
 // BlockParagraph
 const blockParagraph = z

--- a/pkgs/models/src/components/test.helper.ts
+++ b/pkgs/models/src/components/test.helper.ts
@@ -1,6 +1,8 @@
 import { nanoid, slugify } from '@specfy/core';
 import type { Projects } from '@specfy/db';
 
+import type { ApiBlobComponent } from '../blobs/types.api.js';
+
 import type { DBComponent } from './types.js';
 
 export function getBlobComponent(
@@ -32,6 +34,25 @@ export function getBlobComponent(
     sourcePath: [],
     tags: [],
     show: true,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+export function getApiBlobComponent(
+  project: Pick<Projects, 'orgId' | 'id'>
+): ApiBlobComponent {
+  const id = nanoid();
+  const comp = getBlobComponent(project);
+  return {
+    id: nanoid(),
+    created: true,
+    current: comp,
+    deleted: false,
+    type: 'component',
+    typeId: id,
+    previous: null,
+    parentId: null,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
   };

--- a/pkgs/models/src/flows/__snapshots__/helpers.rebuild.test.ts.snap
+++ b/pkgs/models/src/flows/__snapshots__/helpers.rebuild.test.ts.snap
@@ -33,6 +33,7 @@ exports[`rebuildFlow > should create a new flow 1`] = `
         "type": "project",
         "typeId": null,
       },
+      "hidden": false,
       "id": "a",
       "position": {
         "x": 0,
@@ -56,6 +57,7 @@ exports[`rebuildFlow > should create a new flow 1`] = `
         "type": "project",
         "typeId": null,
       },
+      "hidden": false,
       "id": "b",
       "position": {
         "x": 0,

--- a/pkgs/models/src/flows/layout.test.ts
+++ b/pkgs/models/src/flows/layout.test.ts
@@ -15,6 +15,7 @@ function getComp(id: string, host: string | null = null): ComponentForFlow {
     techId: null,
     display: { pos: { x: 0, y: 0 }, size: { width: 100, height: 20 } },
     source: null,
+    show: true,
   };
 }
 

--- a/pkgs/models/src/flows/transform.ts
+++ b/pkgs/models/src/flows/transform.ts
@@ -122,7 +122,7 @@ export function componentsToFlow(components: ComponentForFlow[]): ComputedFlow {
         target: edge.target,
         sourceHandle: edge.portSource,
         targetHandle: edge.portTarget,
-        data: { read: edge.read, write: edge.write },
+        data: { read: edge.read, write: edge.write, source: edge.source },
         hidden: edge.show === false,
         ...getEdgeMarkers(edge),
         // type: 'floating',

--- a/pkgs/models/src/flows/transform.ts
+++ b/pkgs/models/src/flows/transform.ts
@@ -24,6 +24,7 @@ export function createNodeFromProject(
     techId: null,
     typeId: null,
     source: null,
+    show: true,
   });
 }
 
@@ -46,6 +47,7 @@ export function createNode(
       width: `${component.display.size.width}px`,
       height: `${component.display.size.height}px`,
     },
+    hidden: component.show === false,
   };
 
   if (component.inComponent.id) {
@@ -121,6 +123,7 @@ export function componentsToFlow(components: ComponentForFlow[]): ComputedFlow {
         sourceHandle: edge.portSource,
         targetHandle: edge.portTarget,
         data: { read: edge.read, write: edge.write },
+        hidden: edge.show === false,
         ...getEdgeMarkers(edge),
         // type: 'floating',
       };

--- a/pkgs/models/src/flows/types.ts
+++ b/pkgs/models/src/flows/types.ts
@@ -97,5 +97,5 @@ export interface FlowEdge {
   portSource: 'sb' | 'sl' | 'sr' | 'st';
   portTarget: 'tb' | 'tl' | 'tr' | 'tt';
   source?: string | undefined;
-  show?: boolean;
+  show?: boolean | undefined;
 }

--- a/pkgs/models/src/flows/types.ts
+++ b/pkgs/models/src/flows/types.ts
@@ -34,6 +34,7 @@ export type ComponentForFlow = Pick<
   | 'type'
   | 'typeId'
   | 'source'
+  | 'show'
 >;
 
 export interface NodeData {
@@ -95,4 +96,5 @@ export interface FlowEdge {
   portSource: 'sb' | 'sl' | 'sr' | 'st';
   portTarget: 'tb' | 'tl' | 'tr' | 'tt';
   source?: string | undefined;
+  show?: boolean;
 }

--- a/pkgs/models/src/flows/types.ts
+++ b/pkgs/models/src/flows/types.ts
@@ -50,6 +50,7 @@ export interface NodeData {
 export interface EdgeData {
   read: boolean;
   write: boolean;
+  source?: FlowEdge['source'];
 }
 
 export type ComputedNode = Node<NodeData>;

--- a/pkgs/models/src/flows/validator.ts
+++ b/pkgs/models/src/flows/validator.ts
@@ -49,9 +49,10 @@ export const schemaEdges = z.array(
       portSource: schemaPortSource,
       portTarget: schemaPortTarget,
       source: schemaSource,
+      show: z.boolean(),
     })
     .strict()
-    .partial({ source: true })
+    .partial({ source: true, show: true })
 );
 
 export const schemaFlowUpdate = z
@@ -62,10 +63,8 @@ export const schemaFlowUpdate = z
         .object({
           sourceHandle: schemaPortSource,
           targetHandle: schemaPortTarget,
-          source: schemaSource,
         })
         .strict()
-        .partial({ source: true })
     ),
     nodes: z.record(schemaId, z.object({ display: schemaDisplay }).strict()),
   })

--- a/pkgs/models/src/flows/validator.ts
+++ b/pkgs/models/src/flows/validator.ts
@@ -58,10 +58,14 @@ export const schemaFlowUpdate = z
   .object({
     edges: z.record(
       z.string().regex(edgeId),
-      z.object({
-        sourceHandle: schemaPortSource,
-        targetHandle: schemaPortTarget,
-      })
+      z
+        .object({
+          sourceHandle: schemaPortSource,
+          targetHandle: schemaPortTarget,
+          source: schemaSource,
+        })
+        .strict()
+        .partial({ source: true })
     ),
     nodes: z.record(schemaId, z.object({ display: schemaDisplay }).strict()),
   })


### PR DESCRIPTION
Closes #187 

## Context
Components and Edges found by the Stack Analyzer can sometimes be too much, especially with monorepo.
Deleting those items is not a viable option since they will be recreated at next deploy. So we can hide them.

There is now a state for `show: true|false` for components and edges. There is a button dedicated to this in the Flow and the dedicated components pages. 

The behavior is: 
- Deleting a managed component should hide it. 
- Deleting a managed edge should hide it. 
- We can hide/show any others components/edges too.
- Visual Diff should reflect this change

## Additional changes
- Added test to cover component diff
- Fixed: edge display changes was not registered in the staging area (e.g: port change)
- Fixed: diffing `techs` wasn't correct
- Fixed: Dropdown portal was called twice
