### PR TITLE
feat(deploys): store and display full logs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21979,9 +21979,7 @@
         "@specfy/models": "file:../models",
         "@specfy/stack-analyser": "1.5.0",
         "consola": "3.2.3",
-        "figures": "5.0.0",
-        "kleur": "4.1.5",
-        "ora": "7.0.1"
+        "figures": "5.0.0"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "6.4.0",

--- a/pkgs/api/src/routes/v0/jobs/create.ts
+++ b/pkgs/api/src/routes/v0/jobs/create.ts
@@ -1,6 +1,6 @@
 import { schemaOrgId, schemaId } from '@specfy/core';
 import { prisma } from '@specfy/db';
-import { createJobDeploy, toApiJob } from '@specfy/models';
+import { createJobDeploy, toApiJobList } from '@specfy/models';
 import type { PostJob } from '@specfy/models';
 import type { FastifyPluginCallback, FastifyRequest } from 'fastify';
 import z from 'zod';
@@ -72,7 +72,7 @@ const fn: FastifyPluginCallback = (fastify, _, done) => {
       }
 
       return res.status(200).send({
-        data: toApiJob({ ...job, User: me }),
+        data: toApiJobList({ ...job, User: me }),
       });
     }
   );

--- a/pkgs/api/src/routes/v0/jobs/get.test.ts
+++ b/pkgs/api/src/routes/v0/jobs/get.test.ts
@@ -69,6 +69,7 @@ describe('GET /jobs/:job_id', () => {
       reason: null,
       status: 'pending',
       type: 'deploy',
+      logs: '',
       typeId: expect.any(Number),
       user: {
         avatarUrl: null,

--- a/pkgs/api/src/routes/v0/jobs/get.ts
+++ b/pkgs/api/src/routes/v0/jobs/get.ts
@@ -1,3 +1,4 @@
+import { prisma } from '@specfy/db';
 import { toApiJob } from '@specfy/models';
 import type { GetJob } from '@specfy/models';
 import type { FastifyPluginCallback } from 'fastify';
@@ -7,8 +8,19 @@ import { getJob } from '../../../middlewares/getJob.js';
 const fn: FastifyPluginCallback = (fastify, _, done) => {
   fastify.get<GetJob>('/', { preHandler: [getJob] }, async function (req, res) {
     const job = req.job!;
+    let logs = '';
+
+    if (job.logsId) {
+      const row = await prisma.logs.findFirst({
+        where: { id: job.logsId },
+      });
+      if (row?.content) {
+        logs = row.content;
+      }
+    }
+
     return res.status(200).send({
-      data: toApiJob(job),
+      data: toApiJob(job, logs),
     });
   });
   done();

--- a/pkgs/api/src/routes/v0/jobs/list.ts
+++ b/pkgs/api/src/routes/v0/jobs/list.ts
@@ -2,7 +2,7 @@ import { schemaId, schemaOrgId } from '@specfy/core';
 import type { Pagination } from '@specfy/core';
 import type { Prisma } from '@specfy/db';
 import { prisma } from '@specfy/db';
-import { toApiJob } from '@specfy/models';
+import { toApiJobList } from '@specfy/models';
 import type { ListJobs } from '@specfy/models';
 import type { FastifyPluginCallback, FastifyRequest } from 'fastify';
 import { z } from 'zod';
@@ -58,7 +58,7 @@ const fn: FastifyPluginCallback = (fastify, _, done) => {
 
     return res.status(200).send({
       data: list.map((job) => {
-        return toApiJob(job);
+        return toApiJobList(job);
       }),
       pagination,
     });

--- a/pkgs/api/src/test/__fixtures__/log-deploy-success.json
+++ b/pkgs/api/src/test/__fixtures__/log-deploy-success.json
@@ -1,0 +1,38 @@
+{"level":30,"time":1694693615847,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"Job start","data":{"id":"IlvHCKFbkiza","orgId":"acme","projectId":"lduAoo0LT6VS"}}
+{"level":30,"time":1694693615851,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"Configuration","data":{"ref":"main","job":{"url":"specfy/Demo","autoLayout":true,"project":{"branch":"main","documentation":{"enabled":true,"path":"/"},"stack":{"enabled":true,"path":"/"}}}}}
+{"level":30,"time":1694693615851,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"Getting temporary token from GitHub","data":{}}
+{"level":30,"time":1694693616134,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"Creating GitHub deployment in GitHub","data":{}}
+{"level":30,"time":1694693617172,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"Deployment available: https://github.com/specfy/Demo/deployments","data":{}}
+{"level":30,"time":1694693617172,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"Updating deployment status","data":{}}
+{"level":30,"time":1694693618294,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"Cloning repository","data":{}}
+{"level":30,"time":1694693619079,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"","data":{}}
+{"level":30,"time":1694693619079,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"-- Documentation","data":{}}
+{"level":30,"time":1694693619079,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"▶ Syncing /tmp/specfy_clone_IlvHCKFbkiza_nZt1P0U9C4rG/","data":{}}
+{"level":30,"time":1694693619079,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"Listing...","data":{}}
+{"level":30,"time":1694693619080,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"Listed ✔","data":{}}
+{"level":30,"time":1694693619080,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"Parsing...","data":{}}
+{"level":30,"time":1694693619081,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"Parsed ✔","data":{}}
+{"level":30,"time":1694693619081,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"→ Found 4 files","data":{"files":["/README.md","/docs/Contributing.md","/docs/Installation.md","/docs/Introducion.md"]}}
+{"level":30,"time":1694693619081,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"","data":{}}
+{"level":30,"time":1694693619081,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"","data":{}}
+{"level":30,"time":1694693619081,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"-- Stack","data":{}}
+{"level":30,"time":1694693619081,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"▶ Syncing: /tmp/specfy_clone_IlvHCKFbkiza_nZt1P0U9C4rG/","data":{}}
+{"level":30,"time":1694693619081,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"Analyzing...","data":{}}
+{"level":30,"time":1694693619103,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"Analyzed ✔","data":{}}
+{"level":30,"time":1694693619104,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"","data":{}}
+{"level":30,"time":1694693619104,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"-- Deploy","data":{}}
+{"level":30,"time":1694693619104,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"Uploading to Specfy...","data":{}}
+{"level":30,"time":1694693619104,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"POST http://127.0.0.1:3000/0/revisions/upload","data":{}}
+{"level":30,"time":1694693619251,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"GET http://127.0.0.1:3000/0/revisions/1egjNFZIgEj2?org_id=acme&project_id=lduAoo0LT6VS","data":{}}
+{"level":30,"time":1694693619263,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"Uploaded ✔","data":{}}
+{"level":30,"time":1694693619263,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"","data":{}}
+{"level":30,"time":1694693619263,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"▶ Revision created: http://localhost:5173/acme/demo/revisions/1egjNFZIgEj2","data":{}}
+{"level":30,"time":1694693619263,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"","data":{}}
+{"level":30,"time":1694693619263,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"Closing old revisions","data":{}}
+{"level":30,"time":1694693619264,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"GET http://127.0.0.1:3000/0/revisions?org_id=acme&project_id=lduAoo0LT6VS&search=fix%3A+sync+from+git&status=opened","data":{}}
+{"level":30,"time":1694693619280,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"Closed (0) ✔","data":{}}
+{"level":30,"time":1694693619280,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"Merging","data":{}}
+{"level":30,"time":1694693619280,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"POST http://127.0.0.1:3000/0/revisions/1egjNFZIgEj2/merge?org_id=acme&project_id=lduAoo0LT6VS","data":{}}
+{"level":30,"time":1694693619382,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"Merged ✔","data":{}}
+{"level":30,"time":1694693619382,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"Cleaning","data":{}}
+{"level":30,"time":1694693619386,"serviceContext":{"service":"specfy"},"svc":"jobs","jobId":"IlvHCKFbkiza","message":"Updating GitHub deployment status","data":{}}

--- a/pkgs/api/src/test/__fixtures__/test-code.md
+++ b/pkgs/api/src/test/__fixtures__/test-code.md
@@ -38,8 +38,11 @@ Configuration =>
   "url": "specfy/sync"
 }
 Processing ["2023-08-28T13:14:10.158Z"]
-Status ["success"]
+Status: "success"
 Finished ["2023-08-28T13:14:10.158Z"]
+INFO foobar
+ERROR Got 5 errors
+WARN This a fair warning true / false
 ```
 
 ## Css

--- a/pkgs/api/src/test/seed/jobs.ts
+++ b/pkgs/api/src/test/seed/jobs.ts
@@ -1,3 +1,7 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { dirname, nanoid } from '@specfy/core';
 import type { Orgs, Projects, Users } from '@specfy/db';
 import { prisma } from '@specfy/db';
 import { createJobDeploy, jobReason } from '@specfy/models';
@@ -87,6 +91,21 @@ export async function seedJobs(
         tx,
       }),
     ]);
+
+    const logs = await fs.readFile(
+      path.join(dirname, '../api/src/test/__fixtures__/log-deploy-success.json')
+    );
+    await tx.jobs.update({
+      data: {
+        Log: {
+          create: {
+            id: nanoid(),
+            content: logs.toString(),
+          },
+        },
+      },
+      where: { id: '53QoA4sTeI06' },
+    });
   });
 }
 

--- a/pkgs/app/src/components/CodeHighlighter/index.module.scss
+++ b/pkgs/app/src/components/CodeHighlighter/index.module.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 .code {
   display: flex !important;
 
@@ -26,5 +27,27 @@
     letter-spacing: inherit;
 
     -webkit-font-smoothing: antialiased;
+  }
+
+  :global {
+    .language-log {
+      .token.error {
+        font-weight: 500;
+        color: var(--tomato-9);
+      }
+
+      .token.keyword {
+        color: var(--blue-9);
+      }
+
+      .token.property {
+        color: var(--purple-9);
+      }
+
+      .token.url {
+        color: var(--indigo-10);
+        text-decoration: underline;
+      }
+    }
   }
 }

--- a/pkgs/app/src/components/CodeHighlighter/index.tsx
+++ b/pkgs/app/src/components/CodeHighlighter/index.tsx
@@ -23,12 +23,15 @@ export const CodeHighlighter: React.FC<{ language: string; code: string }> = ({
 }) => {
   useEffect(() => {
     Prism.highlightAll();
-  }, []);
+  }, [code]);
 
   return (
     <div className={cls.code}>
       <pre>
-        <code className={`language-${language}`}>{code}</code>
+        <code
+          className={`language-${language}`}
+          dangerouslySetInnerHTML={{ __html: code }}
+        ></code>
       </pre>
     </div>
   );

--- a/pkgs/app/src/views/Project/Deploy/Show/index.module.scss
+++ b/pkgs/app/src/views/Project/Deploy/Show/index.module.scss
@@ -3,6 +3,10 @@
   padding: var(--spc-6xl);
 }
 
+.banner {
+  padding: var(--spc-2xl) var(--spc-6xl);
+}
+
 .states {
   padding: 0 var(--spc-6xl) var(--spc-6xl) var(--spc-6xl);
 }

--- a/pkgs/app/src/views/Project/Deploy/Show/index.tsx
+++ b/pkgs/app/src/views/Project/Deploy/Show/index.tsx
@@ -78,7 +78,10 @@ export const ProjectDeploysShow: React.FC<{
     }
 
     const tmp: string[] = [];
-    tmp.push(`Created ["${deploy.createdAt}"]`);
+    tmp.push(`Created: "${deploy.createdAt}"`);
+    if (deploy.startedAt) {
+      tmp.push(`Started: "${deploy.startedAt}"`);
+    }
 
     const split = deploy.logs.split('\n');
     for (const l of split) {
@@ -97,13 +100,13 @@ export const ProjectDeploysShow: React.FC<{
     }
 
     if (deploy.finishedAt) {
+      tmp.push(`---`);
+      tmp.push(`Finished: "${deploy.finishedAt}"`);
+      tmp.push(`Status: "${deploy.status}"`);
       if (deploy.reason && deploy.status !== 'success') {
-        tmp.push(`ERROR [code: "${deploy.reason.code}"]`);
-        tmp.push(`ERROR ${deploy.reason.reason}`);
+        tmp.push(`Code: "${deploy.reason.code}"`);
+        tmp.push(`${deploy.reason.reason}`);
       }
-      tmp.push(`Status ["${deploy.status}"]`);
-
-      tmp.push(`Finished ["${deploy.finishedAt}"]  `);
     }
     return tmp;
   }, [deploy]);
@@ -156,9 +159,10 @@ export const ProjectDeploysShow: React.FC<{
           </div>
         </Flex>
         {deploy.status === 'failed' && deploy.reason && (
-          <div className={cls.header}>
+          <div className={cls.banner}>
             <Banner type="error">
-              {deploy.reason.reason} (code: {deploy.reason.code})
+              {deploy.reason.reason} <br />
+              (code: {deploy.reason.code})
             </Banner>
           </div>
         )}

--- a/pkgs/app/src/views/Project/Welcome/index.tsx
+++ b/pkgs/app/src/views/Project/Welcome/index.tsx
@@ -1,4 +1,4 @@
-import type { ApiJob } from '@specfy/models';
+import type { ApiJobList } from '@specfy/models';
 import { useState } from 'react';
 import Skeleton from 'react-loading-skeleton';
 import { useNavigate } from 'react-router-dom';
@@ -16,7 +16,7 @@ import { useEventBus } from '@/hooks/useEventBus';
 
 export const ProjectWelcome: React.FC = () => {
   const { project } = useProjectStore();
-  const [job, setJob] = useState<ApiJob>();
+  const [job, setJob] = useState<ApiJobList>();
   const navigate = useNavigate();
 
   useEventBus(

--- a/pkgs/db/prisma/migrations/20230914121437_logs_table/migration.sql
+++ b/pkgs/db/prisma/migrations/20230914121437_logs_table/migration.sql
@@ -1,0 +1,14 @@
+-- AlterTable
+ALTER TABLE "Jobs" ADD COLUMN     "logsId" VARCHAR(15);
+
+-- CreateTable
+CREATE TABLE "Logs" (
+    "id" VARCHAR(15) NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Logs_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Jobs" ADD CONSTRAINT "Jobs_logsId_fkey" FOREIGN KEY ("logsId") REFERENCES "Logs"("id") ON DELETE CASCADE ON UPDATE NO ACTION;

--- a/pkgs/db/prisma/schema.prisma
+++ b/pkgs/db/prisma/schema.prisma
@@ -236,7 +236,7 @@ model Jobs {
   config Json       @db.Json
   /// [PrismaJobsReason]
   reason Json?      @db.Json
-  // logs   String?
+  logsId String?    @db.VarChar(15)
 
   createdAt  DateTime  @default(now()) @db.Timestamp(3)
   startedAt  DateTime? @db.Timestamp(3)
@@ -246,6 +246,7 @@ model Jobs {
   Org     Orgs      @relation(fields: [orgId], references: [id], onDelete: Cascade, onUpdate: NoAction)
   Project Projects? @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: NoAction)
   User    Users?    @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  Log     Logs?     @relation(fields: [logsId], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   // FIXME:  https://github.com/prisma/prisma/issues/6974
   // SELECT WHERE type ORDER BY createdAt
@@ -269,6 +270,15 @@ model Keys {
   Org     Orgs?     @relation(fields: [orgId], references: [id], onDelete: Cascade, onUpdate: NoAction)
   Project Projects? @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: NoAction)
   User    Users     @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+}
+
+model Logs {
+  id      String @id @db.VarChar(15)
+  content String
+
+  createdAt DateTime @default(now()) @db.Timestamp(3)
+
+  Jobs Jobs[]
 }
 
 model Orgs {

--- a/pkgs/github-sync/package.json
+++ b/pkgs/github-sync/package.json
@@ -40,8 +40,6 @@
     "@specfy/core": "file:../core",
     "@specfy/models": "file:../models",
     "consola": "3.2.3",
-    "figures": "5.0.0",
-    "kleur": "4.1.5",
-    "ora": "7.0.1"
+    "figures": "5.0.0"
   }
 }

--- a/pkgs/github-sync/src/__snapshots__/sync.test.ts.snap
+++ b/pkgs/github-sync/src/__snapshots__/sync.test.ts.snap
@@ -17,7 +17,7 @@ exports[`sync > should fail to upload 1`] = `
     "-- Documentation",
   ],
   [
-    "▶ Syncing /Users/samuelbodin/code/specfy/pkgs/api/src/test/__fixtures__/",
+    "▶ Syncing /",
   ],
   [
     "Listing...",

--- a/pkgs/github-sync/src/__snapshots__/sync.test.ts.snap
+++ b/pkgs/github-sync/src/__snapshots__/sync.test.ts.snap
@@ -1,0 +1,93 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`sync > should break if path does not exists 1`] = `
+[
+  [
+    "✘ Path for documentation \\"/tmp/fdokfldkjlkgs/\\" does not exist",
+  ],
+]
+`;
+
+exports[`sync > should fail to upload 1`] = `
+[
+  [
+    "",
+  ],
+  [
+    "-- Documentation",
+  ],
+  [
+    "▶ Syncing /Users/samuelbodin/code/specfy/pkgs/api/src/test/__fixtures__/",
+  ],
+  [
+    "Listing...",
+  ],
+  [
+    "Listed ✔",
+  ],
+  [
+    "Parsing...",
+  ],
+  [
+    "Parsed ✔",
+  ],
+  [
+    "→ Found 5 files",
+    {
+      "files": [
+        "/TestLink.md",
+        "/TestLinkRelative.md",
+        "/markdown-spec.md",
+        "/nested/TestLinkNested.md",
+        "/test-code.md",
+      ],
+    },
+  ],
+  [
+    "",
+  ],
+  [
+    "ℹ Stack Skipped",
+  ],
+  [
+    "",
+  ],
+  [
+    "-- Deploy",
+  ],
+  [
+    "Uploading to Specfy...",
+  ],
+  [
+    "POST https://api.specfy.io/0/revisions/upload",
+  ],
+  [
+    "Uploaded ✘",
+  ],
+  [
+    "{
+  \\"code\\": \\"401_unauthorized\\"
+}",
+  ],
+]
+`;
+
+exports[`sync > should stop if nothing is enabled 1`] = `
+[
+  [
+    "",
+  ],
+  [
+    "ℹ Documentation Skipped",
+  ],
+  [
+    "ℹ Stack Skipped",
+  ],
+  [
+    "",
+  ],
+  [
+    "⚠ Nothing to do, did you mean to disable everything?",
+  ],
+]
+`;

--- a/pkgs/github-sync/src/common/helper.ts
+++ b/pkgs/github-sync/src/common/helper.ts
@@ -1,42 +1,63 @@
 import fs from 'node:fs/promises';
 
-import { l } from '@specfy/core';
+import type { Logger } from '@specfy/core';
 import figures from 'figures';
 
-export async function checkPaths(
-  docPath: string,
-  stackPath: string
-): Promise<boolean> {
+export async function checkPaths({
+  docEnabled,
+  docPath,
+  stackEnabled,
+  stackPath,
+  logger,
+}: {
+  docEnabled: boolean;
+  docPath: string;
+  stackEnabled: boolean;
+  stackPath: string;
+  logger: Logger;
+}): Promise<boolean> {
+  const l = logger;
+
   // Check repo path
-  try {
-    const stat = await fs.stat(stackPath);
-    if (!stat.isDirectory()) {
-      l.info(`${figures.cross} Path "${stackPath}" is not a folder`);
+  if (stackEnabled) {
+    try {
+      const stat = await fs.stat(stackPath);
+      if (!stat.isDirectory()) {
+        l.info(
+          `${figures.cross} Path for stack "${stackPath}" is not a folder`
+        );
+        return false;
+      }
+    } catch (e) {
+      l.info(`${figures.cross} Path for stack "${stackPath}" does not exist`);
       return false;
     }
-  } catch (e) {
-    l.info(`${figures.cross} Path "${stackPath}" does not exist`);
-    return false;
   }
 
   // Check docs path
-  try {
-    const stat = await fs.stat(docPath);
-    if (!stat.isDirectory()) {
-      l.info(`${figures.cross} Path "${docPath}" is not a folder`);
+  if (docEnabled) {
+    try {
+      const stat = await fs.stat(docPath);
+      if (!stat.isDirectory()) {
+        l.info(
+          `${figures.cross} Path for documentation "${docPath}" is not a folder`
+        );
+        return false;
+      }
+    } catch (e) {
+      l.info(
+        `${figures.cross} Path for documentation "${docPath}" does not exist`
+      );
       return false;
     }
-  } catch (e) {
-    l.info(`${figures.cross} Path "${docPath}" does not exist`);
-    return false;
   }
 
   return true;
 }
 
-export function checkNothingMsg() {
-  l.info('');
-  l.info(
+export function checkNothingMsg(logger: Logger) {
+  logger.info('');
+  logger.info(
     `${figures.warning} Nothing to do, did you mean to disable everything?`
   );
 }

--- a/pkgs/github-sync/src/common/helper.ts
+++ b/pkgs/github-sync/src/common/helper.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs/promises';
 
 import { l } from '@specfy/core';
 import figures from 'figures';
-import kleur from 'kleur';
 
 export async function checkPaths(
   docPath: string,
@@ -12,17 +11,11 @@ export async function checkPaths(
   try {
     const stat = await fs.stat(stackPath);
     if (!stat.isDirectory()) {
-      l.info(
-        kleur.bold().red(figures.cross),
-        `Path "${stackPath}" is not a folder`
-      );
+      l.info(`${figures.cross} Path "${stackPath}" is not a folder`);
       return false;
     }
   } catch (e) {
-    l.info(
-      kleur.bold().red(figures.cross),
-      `Path "${stackPath}" does not exist`
-    );
+    l.info(`${figures.cross} Path "${stackPath}" does not exist`);
     return false;
   }
 
@@ -30,14 +23,11 @@ export async function checkPaths(
   try {
     const stat = await fs.stat(docPath);
     if (!stat.isDirectory()) {
-      l.info(
-        kleur.bold().red(figures.cross),
-        `Path "${docPath}" is not a folder`
-      );
+      l.info(`${figures.cross} Path "${docPath}" is not a folder`);
       return false;
     }
   } catch (e) {
-    l.info(kleur.bold().red(figures.cross), `Path "${docPath}" does not exist`);
+    l.info(`${figures.cross} Path "${docPath}" does not exist`);
     return false;
   }
 
@@ -47,10 +37,6 @@ export async function checkPaths(
 export function checkNothingMsg() {
   l.info('');
   l.info(
-    kleur
-      .bold()
-      .cyan(
-        `${figures.warning} Nothing to do, did you mean to disable everything?`
-      )
+    `${figures.warning} Nothing to do, did you mean to disable everything?`
   );
 }

--- a/pkgs/github-sync/src/index.ts
+++ b/pkgs/github-sync/src/index.ts
@@ -2,8 +2,8 @@ import { syncFolder } from './helpers.js';
 import { listing } from './listing/index.js';
 import { BaseProvider, ProviderFile } from './provider/base.js';
 import { FSProvider, FSProviderOptions } from './provider/fs.js';
-import { sync } from './sync.js';
+import { sync, ErrorSync } from './sync.js';
 import { transform } from './transform/index.js';
 
 export { BaseProvider, FSProvider, FSProviderOptions, ProviderFile };
-export { listing, sync, transform, syncFolder };
+export { listing, sync, ErrorSync, transform, syncFolder };

--- a/pkgs/github-sync/src/sync.test.ts
+++ b/pkgs/github-sync/src/sync.test.ts
@@ -7,8 +7,8 @@ import type { SyncOptions } from './sync.js';
 import { ErrorSync, sync } from './sync.js';
 
 function getLogger() {
-  const msgs: any[] = [];
-  const log = (...args: any) => msgs.push(args);
+  const msgs: Array<Array<string | object>> = [];
+  const log = (...args: string[]) => msgs.push(args);
   const logger: Logger = {
     info: log,
     error: log,
@@ -69,6 +69,15 @@ describe('sync', () => {
         stackEnabled: false,
       })
     ).rejects.toThrowError(new ErrorSync('failed_to_upload'));
+
+    // Clean snapshot
+    msgs.forEach((row) =>
+      row.forEach((msg, i) => {
+        if (typeof msg === 'string') {
+          row[i] = msg.replace(root, '');
+        }
+      })
+    );
     expect(msgs).toMatchSnapshot();
   });
 });

--- a/pkgs/github-sync/src/sync.test.ts
+++ b/pkgs/github-sync/src/sync.test.ts
@@ -1,0 +1,74 @@
+import path from 'node:path';
+
+import { dirname, type Logger } from '@specfy/core';
+import { describe, expect, it } from 'vitest';
+
+import type { SyncOptions } from './sync.js';
+import { ErrorSync, sync } from './sync.js';
+
+function getLogger() {
+  const msgs: any[] = [];
+  const log = (...args: any) => msgs.push(args);
+  const logger: Logger = {
+    info: log,
+    error: log,
+    warn: log,
+    debug: log,
+    fatal: log,
+  } as unknown as Logger;
+  return { msgs, logger };
+}
+
+function syncDefault(folder?: string): Omit<SyncOptions, 'logger'> {
+  const root = folder || '/tmp/fdokfldkjlkgs';
+  return {
+    root,
+    orgId: 'acme',
+    projectId: 'dkjdkjf',
+    token: '',
+    autoLayout: true,
+    docEnabled: true,
+    docPath: `${root}/`,
+    stackEnabled: true,
+    stackPath: `${root}/`,
+  };
+}
+describe('sync', () => {
+  it('should stop if nothing is enabled', async () => {
+    const { msgs, logger } = getLogger();
+    const res = await sync({
+      ...syncDefault(),
+      logger,
+      docEnabled: false,
+      stackEnabled: false,
+    });
+    expect(res).toBeUndefined();
+    expect(msgs).toMatchSnapshot();
+  });
+
+  it('should break if path does not exists', async () => {
+    const { msgs, logger } = getLogger();
+    await expect(() =>
+      sync({
+        ...syncDefault(),
+        logger,
+        docEnabled: true,
+        stackEnabled: false,
+      })
+    ).rejects.toThrowError(new Error('sync_invalid_path'));
+    expect(msgs).toMatchSnapshot();
+  });
+
+  it('should fail to upload', async () => {
+    const { msgs, logger } = getLogger();
+    const root = path.join(dirname, '../api/src/test/__fixtures__');
+    await expect(() =>
+      sync({
+        ...syncDefault(root),
+        logger,
+        stackEnabled: false,
+      })
+    ).rejects.toThrowError(new ErrorSync('failed_to_upload'));
+    expect(msgs).toMatchSnapshot();
+  });
+});

--- a/pkgs/github-sync/src/sync.ts
+++ b/pkgs/github-sync/src/sync.ts
@@ -1,7 +1,5 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import timer from 'node:timers/promises';
-import util from 'node:util';
 
 import type { Logger } from '@specfy/core';
 import { l as defaultLogger } from '@specfy/core';
@@ -13,8 +11,6 @@ import {
   rules,
 } from '@specfy/stack-analyser';
 import figures from 'figures';
-import kleur from 'kleur';
-import ora from 'ora';
 
 import { checkNothingMsg, checkPaths } from './common/helper.js';
 import { listing } from './listing/index.js';
@@ -43,7 +39,6 @@ export async function sync({
   docPath,
   stackEnabled,
   stackPath,
-  dryRun,
   autoLayout,
   hostname = 'https://api.specfy.io',
   logger = defaultLogger,
@@ -56,7 +51,6 @@ export async function sync({
   docPath: string;
   stackEnabled: boolean;
   stackPath: string;
-  dryRun: boolean;
   autoLayout: boolean;
   hostname?: string;
   logger?: Logger;
@@ -74,14 +68,9 @@ export async function sync({
   let docs: TransformedFile[] = [];
   if (docEnabled) {
     l.info('-- Documentation');
-    l.info(
-      kleur.bold().magenta(`${figures.triangleRight} Syncing`),
-      kleur.cyan(docPath)
-    );
-    const spinnerListing = ora(`Listing`).start();
+    l.info(`${figures.triangleRight} Syncing ${docPath}`);
 
-    await timer.setTimeout(100);
-
+    l.info('Listing...');
     // --- List
     const list: ProviderFile[] = [];
     const provider = new FSProvider({
@@ -96,24 +85,20 @@ export async function sync({
       },
       '/'
     );
-    spinnerListing.succeed('Listed');
+    l.info(`Listed ${figures.tick}`);
 
     // --- Transform
-    const spinnerParsing = ora(`Parsing`).start();
+    l.info('Parsing...');
     docs = await transform(provider, list);
-    spinnerParsing.succeed('Parsed');
+    l.info(`Parsed ${figures.tick}`);
 
     // Log
-    l.info(
-      kleur.bold().blue(`${figures.arrowRight}`),
-      'Found',
-      list.length,
-      'files'
-    );
-    l.info(list.map((file) => file.fp));
+    l.info(`${figures.arrowRight} Found ${list.length} files`, {
+      files: list.map((file) => file.fp),
+    });
     l.info('');
   } else {
-    l.info(kleur.bold().yellow(`${figures.info} Documentation Skipped`));
+    l.warn(`${figures.info} Documentation Skipped`);
   }
 
   // ------- Stack
@@ -122,12 +107,9 @@ export async function sync({
     l.info('');
     l.info('-- Stack');
 
-    l.info(
-      kleur.bold().magenta(`${figures.triangleRight} Syncing`),
-      kleur.cyan(stackPath)
-    );
+    l.info(`${figures.triangleRight} Syncing: ${stackPath}`);
 
-    const spinner = ora(`Analysing ${stackPath}`).start();
+    l.info(`Analyzing...`);
     stack = flatten(
       await analyser({
         provider: new StackProvider({
@@ -136,19 +118,15 @@ export async function sync({
         }),
       })
     );
-
-    spinner.succeed('Analysed');
+    l.info(`Analyzed ${figures.tick}`);
 
     // output to folder for debug / manual review
     const file = path.join(root, 'stack.json');
     await fs.writeFile(file, JSON.stringify(stack.toJson(root), undefined, 2));
-    l.info(
-      kleur.bold().blue(`${figures.arrowRight}`),
-      'Output',
-      kleur.green(file)
-    );
+    // l.info(`${figures.arrowRight} Output`);
+    // l.info('Stack', stack.toJson(root));
   } else {
-    l.info(kleur.bold().yellow(`${figures.info} Stack Skipped`));
+    l.warn(`${figures.info} Stack Skipped`);
   }
 
   if (!docEnabled && !stackEnabled) {
@@ -159,7 +137,7 @@ export async function sync({
   // --- Upload
   l.info('');
   l.info('-- Deploy');
-  const spinnerUploading = ora(`Uploading`).start();
+  l.info('Uploading to Specfy...');
   const body = prepBody({
     orgId,
     projectId,
@@ -170,13 +148,6 @@ export async function sync({
     root,
   });
 
-  if (dryRun) {
-    spinnerUploading.stopAndPersist({ text: 'Uploaded (dry-run)' });
-    l.info('');
-    l.info(util.inspect(body, false, 10, true));
-    return;
-  }
-
   const resUp = await upload({ body, token, baseUrl, logger });
   if ('error' in resUp) {
     // There is nothing to commit
@@ -184,24 +155,24 @@ export async function sync({
       resUp.error.code === 'cant_create' &&
       resUp.error.reason === 'no_diff'
     ) {
-      spinnerUploading.succeed('Uploaded');
-      l.info(kleur.bold().blue(`${figures.info} No diff with production`));
+      l.info(`Uploaded ${figures.tick}`);
+      l.info(`${figures.info} No diff with production`);
 
       // It's perfectly okay that there is no diff, could be that we have found nothing or just nothing has changed
       return;
     }
 
-    spinnerUploading.fail('Uploaded');
+    l.error(`Uploaded ${figures.cross}`);
 
     l.info('');
-    l.error(kleur.red('Failed to upload, received:'));
+    l.error('Failed to upload, received:');
     l.error(JSON.stringify(resUp.error, null, 2));
 
     throw new Error('Failed to upload');
   }
 
   if (resUp.data.stats.stack && resUp.data.stats.stack?.deleted > 1) {
-    l.error(resUp.data.stats, kleur.red('Fail Safe: too many deletion'));
+    l.error(resUp.data.stats, 'Fail Safe: too many deletion');
     throw new Error('Too many deletion in the revision');
   }
 
@@ -216,13 +187,14 @@ export async function sync({
     logger,
   });
   const get = await resGet.json();
-  spinnerUploading.succeed('Uploaded');
+  l.info(`Uploaded ${figures.tick}`);
 
   l.info('');
-  l.info('> Revision created:', kleur.underline(get.data.url));
+  l.info(`${figures.triangleRight} Revision created: ${get.data.url}`);
 
-  // --- Deduping
-  const spinnerDedup = ora(`Closing old revisions`).start();
+  // --- Deduplication
+  l.info('');
+  l.info('Closing old revisions');
   const count = await closeOldRevisions({
     id,
     orgId,
@@ -231,9 +203,9 @@ export async function sync({
     baseUrl,
     logger,
   });
-  spinnerDedup.succeed(`Closing old revisions (${count})`);
+  l.info(`Closed (${count}) ${figures.tick}`);
 
-  const spinnerMerge = ora(`Merging`).start();
+  l.info(`Merging`);
   await merge({ id, orgId, projectId, token, baseUrl, logger });
-  spinnerMerge.succeed(`Merged`);
+  l.info(`Merged ${figures.tick}`);
 }

--- a/pkgs/github-sync/src/upload/index.ts
+++ b/pkgs/github-sync/src/upload/index.ts
@@ -56,7 +56,7 @@ export async function upload({
   body: PostUploadRevision['Body'];
 }): Promise<PostUploadRevision['Reply']> {
   const endpoint = `${baseUrl}/revisions/upload`;
-  logger.info('Uploading to', { endpoint });
+  logger.info(`POST ${endpoint}`);
   const res = await fetch(endpoint, {
     method: 'POST',
     body: JSON.stringify(body),
@@ -82,7 +82,7 @@ export async function getRevision({
   id: string;
 }) {
   const endpoint = `${baseUrl}/revisions/${id}?org_id=${orgId}&project_id=${projectId}`;
-  logger.info('Getting revision', { endpoint });
+  logger.info(`GET ${endpoint}`);
   const res = await fetch(endpoint, {
     method: 'GET',
     headers: {
@@ -115,7 +115,7 @@ export async function closeOldRevisions({
     status: 'opened',
   });
   const endpoint = `${baseUrl}/revisions?${usp.toString()}`;
-  logger.info('Listing revisions', { endpoint });
+  logger.info(`GET ${endpoint}`);
 
   const res = await fetch(endpoint, {
     method: 'GET',
@@ -171,7 +171,7 @@ export async function merge({
   id: string;
 }) {
   const endpoint = `${baseUrl}/revisions/${id}/merge?org_id=${orgId}&project_id=${projectId}`;
-  logger.info('Merging revision', { endpoint });
+  logger.info(`POST ${endpoint}`);
 
   const res = await fetch(endpoint, {
     method: 'POST',

--- a/pkgs/github/src/jobs/deploy.ts
+++ b/pkgs/github/src/jobs/deploy.ts
@@ -16,6 +16,161 @@ export class JobDeploy extends Job {
   deployId?: number;
   token?: string;
 
+  async process(job: JobWithOrgProject): Promise<void> {
+    const config = job.config;
+    const l = this.l;
+
+    if (!job.Org || !job.Project) {
+      this.mark('failed', 'missing_dependencies');
+      return;
+    }
+
+    if (!job.Org.githubInstallationId) {
+      this.mark('failed', 'org_not_installed');
+      return;
+    }
+
+    if (!job.Project.githubRepository) {
+      this.mark('failed', 'project_not_installed');
+      return;
+    }
+
+    const projConfig = config.project || job.Project.config;
+    const ref = config.hook?.ref || projConfig.branch;
+    const [owner, repo] = job.Project.githubRepository.split('/');
+
+    this.l.info('Configuration', {
+      ref,
+      job: job.config,
+    });
+
+    // Acquire a special short lived token that allow us to clone the repository
+    try {
+      l.info('Getting temporary token from GitHub');
+      const auth = await github.octokit.rest.apps.createInstallationAccessToken(
+        {
+          installation_id: job.Org.githubInstallationId,
+          repositories: [repo],
+          permissions: {
+            environments: 'write',
+            statuses: 'write',
+            deployments: 'write',
+            contents: 'read',
+          },
+        }
+      );
+      this.token = auth.data.token;
+    } catch (err: unknown) {
+      this.mark('failed', 'cant_auth_github', err);
+      sentry.captureException(err);
+      return;
+    }
+
+    // Notify GitHub that we started deploying
+    try {
+      l.info('Creating GitHub deployment in GitHub');
+
+      const authClient = new Octokit({
+        auth: this.token,
+      });
+      const res = await authClient.rest.repos.createDeployment({
+        owner,
+        repo,
+        ref,
+        environment: `Production - specfy.io/${job.Org.id}/${job.Project.slug}`,
+        production_environment: true,
+        auto_merge: false,
+        required_contexts: [],
+      });
+      if (res.status === 201) {
+        this.deployId = res.data.id;
+
+        l.info(
+          `Deployment available: https://github.com/${owner}/${repo}/deployments`
+        );
+      } else {
+        this.mark('failed', 'failed_to_start_github_deployment');
+        return;
+      }
+
+      l.info('Updating deployment status');
+
+      const projUrl = `${envs.APP_HOSTNAME}/${job.orgId}/${job.Project.slug}`;
+      await authClient.rest.repos.createDeploymentStatus({
+        owner,
+        repo,
+        deployment_id: this.deployId,
+        state: 'in_progress',
+        auto_inactive: true,
+        environment_url: projUrl,
+        log_url: `${projUrl}/deploys/${job.id}`,
+      });
+    } catch (err) {
+      this.mark('failed', 'failed_to_start_github_deployment', err);
+      sentry.captureException(err);
+      return;
+    }
+
+    // Clone into a tmp folder
+    this.folderName = `/tmp/specfy_clone_${job.id}_${nanoid()}`;
+    try {
+      l.info('Cloning repository');
+      const res =
+        await $`git clone --branch ${projConfig.branch} https://x-access-token:${this.token}@github.com/${config.url}.git --depth 1 ${this.folderName}`;
+
+      if (res.exitCode !== 0) {
+        this.mark('failed', 'unknown');
+        return;
+      }
+
+      await fs.access(this.folderName);
+    } catch (err: unknown) {
+      this.mark('failed', 'failed_to_clone', err);
+      sentry.captureException(err);
+      return;
+    }
+
+    const key = await prisma.keys.findFirst({
+      where: {
+        orgId: job.orgId,
+        projectId: job.projectId,
+      },
+    });
+
+    if (!key) {
+      this.mark('failed', 'no_api_key');
+      return;
+    }
+
+    // Execute deploy
+    try {
+      await sync({
+        orgId: job.orgId,
+        projectId: job.projectId!,
+        token: key.id,
+        root: this.folderName,
+        stackEnabled: projConfig.stack.enabled,
+        stackPath: path.join(this.folderName, projConfig.stack.path),
+        docEnabled: projConfig.documentation.enabled,
+        docPath: path.join(this.folderName, projConfig.documentation.path),
+        autoLayout: config.autoLayout === true,
+        hostname: !isProd
+          ? envs.API_HOSTNAME?.replace('localhost', '127.0.0.1')
+          : envs.API_HOSTNAME,
+        logger: this.l,
+      });
+
+      this.mark('success', 'success');
+    } catch (err: unknown) {
+      this.mark('failed', 'failed_to_deploy', err);
+      sentry.captureException(err);
+      return;
+    }
+  }
+
+  /**
+   * Clean up
+   */
   async teardown(job: JobWithOrgProject): Promise<void> {
     const l = this.l;
 
@@ -55,179 +210,12 @@ export class JobDeploy extends Job {
           deployment_id: this.deployId,
           state: mark?.status === 'failed' ? 'error' : 'success',
           environment_url: projUrl,
-          log_url: `${projUrl}/jobs/${job.id}`,
+          log_url: `${projUrl}/deploys/${job.id}`,
         });
       } catch (err) {
         this.l.error('Cant update GitHub deployment status', err);
         sentry.captureException(err);
       }
-    }
-  }
-
-  async process(job: JobWithOrgProject): Promise<void> {
-    const config = job.config;
-    const l = this.l;
-
-    if (!job.Org || !job.Project) {
-      this.mark('failed', 'missing_dependencies');
-      return;
-    }
-
-    if (!job.Org.githubInstallationId) {
-      this.mark('failed', 'org_not_installed');
-      return;
-    }
-
-    if (!job.Project.githubRepository) {
-      this.mark('failed', 'project_not_installed');
-      return;
-    }
-
-    const projConfig = config.project || job.Project.config;
-    const ref = config.hook?.ref || projConfig.branch;
-    const [owner, repo] = job.Project.githubRepository.split('/');
-
-    // Acquire a special short lived token that allow us to clone the repository
-    try {
-      l.info('Getting temporary token from github');
-      const auth = await github.octokit.rest.apps.createInstallationAccessToken(
-        {
-          installation_id: job.Org.githubInstallationId,
-          repositories: [repo],
-          permissions: {
-            environments: 'write',
-            statuses: 'write',
-            deployments: 'write',
-            contents: 'read',
-          },
-        }
-      );
-      this.token = auth.data.token;
-    } catch (err: unknown) {
-      this.mark('failed', 'cant_auth_github', err);
-      sentry.captureException(err);
-      return;
-    }
-
-    // Notify GitHub that we started deploying
-    try {
-      l.info('Creating GitHub deployment in GitHub');
-
-      const authClient = new Octokit({
-        auth: this.token,
-      });
-      const res = await authClient.rest.repos.createDeployment({
-        owner,
-        repo,
-        ref,
-        environment: `Production – specfy.io/${job.Org.id}/${job.Project.slug}`,
-        production_environment: true,
-        auto_merge: false,
-        required_contexts: [],
-      });
-      if (res.status === 201) {
-        this.deployId = res.data.id;
-
-        l.info(
-          `Deployment available: https://github.com/${owner}/${repo}/deployments/${encodeURIComponent(
-            res.data.environment
-          )}`
-        );
-      } else {
-        this.mark('failed', 'failed_to_start_github_deployment');
-        return;
-      }
-
-      l.info('Updating deployment status');
-
-      const projUrl = `${envs.APP_HOSTNAME}/${job.orgId}/${job.Project.slug}`;
-      await authClient.rest.repos.createDeploymentStatus({
-        owner,
-        repo,
-        deployment_id: this.deployId,
-        state: 'in_progress',
-        auto_inactive: true,
-        environment_url: projUrl,
-        log_url: `${projUrl}/deploys/${job.id}`,
-      });
-    } catch (err) {
-      this.mark('failed', 'failed_to_start_github_deployment', err);
-      sentry.captureException(err);
-      return;
-    }
-
-    // Clone into a tmp folder
-    this.folderName = `/tmp/specfy_clone_${job.id}_${nanoid()}`;
-    try {
-      const res =
-        await $`git clone --branch ${projConfig.branch} https://x-access-token:${this.token}@github.com/${config.url}.git --depth 1 ${this.folderName}`;
-
-      if (res.exitCode !== 0) {
-        this.mark('failed', 'unknown');
-        return;
-      }
-
-      await fs.access(this.folderName);
-    } catch (err: unknown) {
-      this.mark('failed', 'failed_to_clone', err);
-      sentry.captureException(err);
-      return;
-    }
-
-    // // Checkout at the correct ref
-    // try {
-    //   const res = await $`cd folder && git checkout ${ref}`;
-
-    //   if (res.exitCode !== 0) {
-    //     this.mark('failed', 'unknown');
-    //     return;
-    //   }
-    // } catch (err: unknown) {
-    //   this.mark('failed', 'failed_to_checkout', err);
-    //   return;
-    // }
-
-    const key = await prisma.keys.findFirst({
-      where: {
-        orgId: job.orgId,
-        projectId: job.projectId,
-      },
-    });
-
-    if (!key) {
-      this.mark('failed', 'no_api_key');
-      return;
-    }
-
-    // Execute deploy
-    try {
-      this.l.info(
-        JSON.stringify({ root: this.folderName, projConfig }),
-        'Start sync with configuration'
-      );
-
-      await sync({
-        orgId: job.orgId,
-        projectId: job.projectId!,
-        token: key.id,
-        root: this.folderName,
-        dryRun: false,
-        stackEnabled: projConfig.stack.enabled,
-        stackPath: path.join(this.folderName, projConfig.stack.path),
-        docEnabled: projConfig.documentation.enabled,
-        docPath: path.join(this.folderName, projConfig.documentation.path),
-        autoLayout: config.autoLayout === true,
-        hostname: !isProd
-          ? envs.API_HOSTNAME?.replace('localhost', '127.0.0.1')
-          : envs.API_HOSTNAME,
-        logger: this.l,
-      });
-
-      this.mark('success', 'success');
-    } catch (err: unknown) {
-      this.mark('failed', 'failed_to_deploy', err);
-      sentry.captureException(err);
-      return;
     }
   }
 }

--- a/pkgs/github/src/service.ts
+++ b/pkgs/github/src/service.ts
@@ -18,7 +18,7 @@ export async function off() {
 }
 
 export function listen() {
-  l.info('Starting');
+  l.info('Service Starting');
 
   // TODO: replace this with a queue and/or Listen/notify
   interval = setInterval(async () => {
@@ -52,9 +52,13 @@ export function listen() {
         },
       });
 
-      const job = new JobDeploy(full);
-      running.push(job);
-      (() => job.start())();
+      try {
+        const job = new JobDeploy(full);
+        running.push(job);
+        (() => job.start())();
+      } catch (e) {
+        l.error(e);
+      }
     });
   }, 5000);
 }

--- a/pkgs/models/src/billing/model.ts
+++ b/pkgs/models/src/billing/model.ts
@@ -3,10 +3,17 @@ import type { Users, Orgs } from '@specfy/db';
 import { Prisma, prisma } from '@specfy/db';
 
 import { BILLING_ENABLED } from './constants.js';
+import type { Plan } from './plans.js';
 import { v1 } from './plans.js';
 import { stripe } from './stripe.js';
 import type { GetBillingUsage } from './types.api.js';
 
+export function getCurrentPlan(org: Orgs): Plan {
+  return (
+    Object.values(v1).find((p) => p.id === org.currentPlanId) ||
+    (BILLING_ENABLED ? v1.free : v1.business)
+  );
+}
 export async function getUsage(
   org: Orgs
 ): Promise<GetBillingUsage['Success']['data']> {
@@ -23,9 +30,7 @@ export async function getUsage(
   );
 
   const counts = res[0];
-  const plan =
-    Object.values(v1).find((p) => p.id === org.currentPlanId) ||
-    (BILLING_ENABLED ? v1.free : v1.business);
+  const plan = getCurrentPlan(org);
 
   const usage: GetBillingUsage['Success']['data'] = {
     projects: {

--- a/pkgs/models/src/billing/plans.ts
+++ b/pkgs/models/src/billing/plans.ts
@@ -36,10 +36,10 @@ export const v1: Record<PlanName, Plan> = {
       max: 5,
     },
     project: {
-      max: 3,
+      max: 10,
     },
     upload: {
-      maxDocuments: 25,
+      maxDocuments: 50,
       maxDocumentSize: 1_999_999,
     },
     deploy: {

--- a/pkgs/models/src/jobs/formatter.ts
+++ b/pkgs/models/src/jobs/formatter.ts
@@ -1,9 +1,9 @@
 import { toApiUser } from '../users/formatter.js';
 
-import type { ApiJob } from './types.api.js';
+import type { ApiJob, ApiJobList } from './types.api.js';
 import type { JobWithUser } from './types.js';
 
-export function toApiJob(job: JobWithUser): ApiJob {
+export function toApiJobList(job: JobWithUser): ApiJobList {
   return {
     id: job.id,
     orgId: job.orgId,
@@ -13,11 +13,16 @@ export function toApiJob(job: JobWithUser): ApiJob {
     status: job.status,
     config: job.config,
     reason: job.reason,
-    // logs: job.logs,
     createdAt: job.createdAt.toISOString(),
     updatedAt: job.updatedAt.toISOString(),
     startedAt: job.startedAt?.toISOString() || null,
     finishedAt: job.finishedAt?.toISOString() || null,
     user: toApiUser(job.User!),
+  };
+}
+export function toApiJob(job: JobWithUser, logs: string): ApiJob {
+  return {
+    ...toApiJobList(job),
+    logs,
   };
 }

--- a/pkgs/models/src/jobs/helpers.ts
+++ b/pkgs/models/src/jobs/helpers.ts
@@ -11,7 +11,14 @@ export const jobReason: Record<JobCode, string> = {
   failed_to_teardown: 'Failed to clean after execution',
   failed_to_checkout: 'Failed to checkout repository at the commit ref',
   failed_to_start_github_deployment: 'Failed to reach GitHub deployment API',
+  failed_to_upload: 'Failed to upload to Specfy API',
+  sync_invalid_path:
+    'A path set in the configuration does not exists on this repository',
   no_api_key: 'No API Key available to deploy',
   unknown: 'An unknown error occured',
   success: 'Success',
+  fail_safe_too_many_deletion:
+    'Deploy was successful, but requires the deletion of more than 1 resources. You can merge manually to resolve this issue.',
+  too_many_documents:
+    'Too many documents uploaded, check the logs and your plan limits or disable documentation upload',
 };

--- a/pkgs/models/src/jobs/types.api.ts
+++ b/pkgs/models/src/jobs/types.api.ts
@@ -5,7 +5,7 @@ import type { ApiUser } from '../users/types.api.js';
 
 import type { JobReason } from './types.js';
 
-export type ApiJob = Pick<
+type ApiJobBase = Pick<
   Jobs,
   'config' | 'id' | 'orgId' | 'projectId' | 'status' | 'type' | 'typeId'
 > & {
@@ -14,20 +14,15 @@ export type ApiJob = Pick<
   updatedAt: string;
   startedAt: string | null;
   finishedAt: string | null;
-  // logs: string | null;
   user: ApiUser;
 };
+export type ApiJobList = ApiJobBase;
+export type ApiJob = ApiJobBase & { logs: string };
 
 // ------ GET /
 export type ListJobs = Res<{
-  Querystring: {
-    org_id: string;
-    project_id: string;
-  };
-  Success: {
-    data: ApiJob[];
-    pagination: Pagination;
-  };
+  Querystring: { org_id: string; project_id: string };
+  Success: { data: ApiJobList[]; pagination: Pagination };
 }>;
 
 // ------ POST /
@@ -44,7 +39,7 @@ export type PostJob = Res<{
     type: Jobs['type'];
   };
   Error: CreateJobError;
-  Success: { data: ApiJob };
+  Success: { data: ApiJobList };
 }>;
 
 // ------ GET /:job_id
@@ -53,10 +48,6 @@ export type GetJob = Res<{
     org_id: string;
     project_id: string;
   };
-  Params: {
-    job_id: string;
-  };
-  Success: {
-    data: ApiJob;
-  };
+  Params: { job_id: string };
+  Success: { data: ApiJob };
 }>;

--- a/pkgs/models/src/jobs/types.ts
+++ b/pkgs/models/src/jobs/types.ts
@@ -29,7 +29,11 @@ export type JobCode =
   | 'org_not_installed'
   | 'project_not_installed'
   | 'success'
-  | 'unknown';
+  | 'unknown'
+  | 'sync_invalid_path'
+  | 'too_many_documents'
+  | 'failed_to_upload'
+  | 'fail_safe_too_many_deletion';
 
 export interface JobMark {
   status: Jobs['status'];

--- a/pkgs/socket/src/types.ts
+++ b/pkgs/socket/src/types.ts
@@ -1,5 +1,5 @@
 import type { Users } from '@specfy/db';
-import type { PermsWithOrg, ApiJob, ApiProject } from '@specfy/models';
+import type { PermsWithOrg, ApiProject, ApiJobList } from '@specfy/models';
 import type { Server } from 'socket.io';
 
 export interface PayloadAuth {
@@ -8,7 +8,7 @@ export interface PayloadAuth {
 }
 
 export type EventJob = {
-  job: ApiJob;
+  job: ApiJobList;
   project: ApiProject;
 };
 


### PR DESCRIPTION
Closes #221 

## Changes

- Created a dedicated table to store raw logs
We are not using the main table to limit impact on query time when listing jobs without needing to read logs.

- Use a double logger to display the log in the console, and store them in a file
It was the easiest to have the two output. Later, we will store the file somewhere else (e.g: GCS) and drop the table entirely.
The problem right now is that `multistream` in Pino does not support formatter, so the output in prod will not be GCP compliant. The ideal long-term solution is to run each job in a container and output all logs to a file.

- Sync
Clean up leftover from when this was a CLI
Add tests to cover the basics.

<img width="975" alt="Screenshot 2023-09-15 at 15 38 31" src="https://github.com/specfy/specfy/assets/1637651/10275946-7671-462c-81c1-1b945fca84ed">

