### PR TITLE
feat(deploy): save computed stack in Database

### DIFF
--- a/pkgs/api/src/routes/v0/revisions/upload.ts
+++ b/pkgs/api/src/routes/v0/revisions/upload.ts
@@ -118,6 +118,7 @@ const fn: FastifyPluginCallback = (fastify, _, done) => {
       }
 
       // TODO: validate all ids
+      // const data: PostUploadRevision['Body'] = val.data;
       const data = val.data;
 
       const project = await prisma.projects.findUnique({
@@ -215,6 +216,7 @@ const fn: FastifyPluginCallback = (fastify, _, done) => {
               status: 'approved',
               merged: false,
               blobs: blobsIds,
+              stack: (data.stack as AnalyserJson) || undefined,
             },
           });
 

--- a/pkgs/api/src/test/seed/e2e.ts
+++ b/pkgs/api/src/test/seed/e2e.ts
@@ -1,0 +1,36 @@
+import path from 'node:path';
+
+import { dirname, envs, l } from '@specfy/core';
+import type { Orgs, Users } from '@specfy/db';
+import { prisma } from '@specfy/db';
+import { sync } from '@specfy/github-sync';
+import { createProject } from '@specfy/models';
+import { getBlobProject } from '@specfy/models/src/projects/test.utils.js';
+
+export async function seedE2E({ o1 }: { o1: Orgs }, users: Users[]) {
+  const pE2E = await createProject({
+    data: { ...getBlobProject(o1), id: 'b06tMzwd5A', name: 'E2E' },
+    user: users[0],
+    tx: prisma,
+  });
+  const key = await prisma.keys.findFirst({
+    select: { id: true },
+    where: { projectId: pE2E.id },
+  });
+
+  const projConfig = pE2E.config;
+  const folderName = path.join(dirname, '../../');
+  await sync({
+    orgId: o1.id,
+    projectId: pE2E.id,
+    token: key!.id,
+    root: folderName,
+    stackEnabled: projConfig.stack.enabled,
+    stackPath: path.join(folderName, projConfig.stack.path),
+    docEnabled: projConfig.documentation.enabled,
+    docPath: path.join(folderName, projConfig.documentation.path),
+    autoLayout: true,
+    hostname: envs.API_HOSTNAME?.replace('localhost', '127.0.0.1'),
+    logger: l,
+  });
+}

--- a/pkgs/api/src/test/seed/index.ts
+++ b/pkgs/api/src/test/seed/index.ts
@@ -3,6 +3,7 @@ import { prisma } from '@specfy/db';
 
 import { seedComponents } from './components.js';
 import { seedDocs, seedPlaybook, seedRFC } from './documents.js';
+import { seedE2E } from './e2e.js';
 import { seedInvitations } from './invitations.js';
 import { seedJobs } from './jobs.js';
 import { seedOrgs } from './orgs.js';
@@ -41,6 +42,9 @@ export async function seed() {
 
   console.log(' - Jobs');
   await seedJobs(users, orgs, projects);
+
+  console.log(' - E2E');
+  await seedE2E(orgs, users);
 
   const def = envs.GIVE_DEFAULT_PERMS_TO_EMAIL;
   if (def) {

--- a/pkgs/db/package.json
+++ b/pkgs/db/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "dotenv": "16.3.1",
     "dotenv-cli": "7.3.0",
-    "typescript": "5.1.6",
-    "prisma-json-types-generator": "2.5.0"
+    "prisma-json-types-generator": "2.5.0",
+    "typescript": "5.1.6"
   }
 }

--- a/pkgs/db/prisma/migrations/20230926084925_add_stack_to_job/migration.sql
+++ b/pkgs/db/prisma/migrations/20230926084925_add_stack_to_job/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Revisions" ADD COLUMN     "stack" JSON;

--- a/pkgs/db/prisma/schema.prisma
+++ b/pkgs/db/prisma/schema.prisma
@@ -411,6 +411,8 @@ model Revisions {
   description Json      @db.Json
   /// [PrismaRevisionsBlobs]
   blobs       Json      @db.Json
+  /// [PrismaRevisionsStack]
+  stack       Json?     @db.Json
   locked      Boolean   @default(false)
   /// [PrismaRevisionsStatus]
   status      String    @default("draft") @db.VarChar(25)

--- a/pkgs/github-sync/src/sync.ts
+++ b/pkgs/github-sync/src/sync.ts
@@ -141,9 +141,6 @@ export async function sync({
     // output to folder for debug / manual review
     const file = path.join(root, 'stack.json');
     await fs.writeFile(file, JSON.stringify(stack.toJson(root), undefined, 2));
-    // l.info(`${figures.arrowRight} Output`);
-    // It's too big to fit inside logs, TODO: find a solution to store this output somewhere
-    console.log('Stack', stack.toJson(root));
   } else {
     l.warn(`${figures.info} Stack Skipped`);
   }

--- a/pkgs/models/src/prisma.d.ts
+++ b/pkgs/models/src/prisma.d.ts
@@ -56,6 +56,7 @@ declare global {
     // Revisions
     type PrismaRevisionsBlobs = DBRevision['blobs'];
     type PrismaRevisionsStatus = DBRevision['status'];
+    type PrismaRevisionsStack = DBRevision['stack'];
 
     // TypeHasUsers
     type PrismaTypeHasUsersRole = DBTypeHasUser['role'];

--- a/pkgs/models/src/revisions/types.api.ts
+++ b/pkgs/models/src/revisions/types.api.ts
@@ -20,7 +20,7 @@ import type { ApiUser } from '../users/types.api.js';
 import type { DocsToBlobs } from './helpers.upload.js';
 import type { DBRevision } from './types.js';
 
-export type ApiRevision = DBRevision & {
+export type ApiRevision = Omit<DBRevision, 'stack'> & {
   authors: ApiUser[];
   url: string;
 };

--- a/pkgs/models/src/revisions/types.ts
+++ b/pkgs/models/src/revisions/types.ts
@@ -1,4 +1,5 @@
 import type { Prisma } from '@specfy/db';
+import type { AnalyserJson } from '@specfy/stack-analyser';
 
 import type { BlockLevelZero } from '../documents';
 
@@ -11,6 +12,7 @@ export interface DBRevision {
   name: string;
   description: BlockLevelZero;
   blobs: string[];
+  stack: AnalyserJson | null;
   locked: boolean;
   status: 'approved' | 'closed' | 'draft' | 'waiting';
   merged: boolean;


### PR DESCRIPTION
- Add `stack` column to `Revisions` 
This will enable more efficient debugging, ability to display what was received in the UI, and in the future tech indexing at merge time for the Catalog.

- Add e2e test 
It self synchronize (aka: your current `specfy` repo) to the local install to have real live data that go through almost regular deployment. Currently it skips `deploy.ts` since it's not a webhook and cloning the repo would be overkill/slow