### PR TITLE
feat(deploy): link revision to deploy 

### DIFF
--- a/pkgs/api/src/middlewares/getJob.ts
+++ b/pkgs/api/src/middlewares/getJob.ts
@@ -40,6 +40,7 @@ export const getJob: PreHandler<{
     },
     include: {
       User: true,
+      Revisions: { select: { id: true } },
     },
   });
 

--- a/pkgs/api/src/routes/v0/jobs/get.test.ts
+++ b/pkgs/api/src/routes/v0/jobs/get.test.ts
@@ -67,6 +67,7 @@ describe('GET /jobs/:job_id', () => {
       orgId: project.orgId,
       projectId: project.id,
       reason: null,
+      revisionId: null,
       status: 'pending',
       type: 'deploy',
       logs: '',

--- a/pkgs/api/src/routes/v0/revisions/get.test.ts
+++ b/pkgs/api/src/routes/v0/revisions/get.test.ts
@@ -68,6 +68,7 @@ describe('GET /revisions/:revision_id', () => {
       orgId: org.id,
       projectId: project.id,
       reviewers: [],
+      stack: null,
       status: 'draft',
       createdAt: expect.toBeIsoDate(),
       updatedAt: expect.toBeIsoDate(),

--- a/pkgs/api/src/routes/v0/revisions/list.test.ts
+++ b/pkgs/api/src/routes/v0/revisions/list.test.ts
@@ -92,7 +92,6 @@ describe('GET /revisions', () => {
       blobs: [],
       closedAt: null,
       createdAt: expect.toBeIsoDate(),
-      description: { content: [], type: 'doc' },
       id: revision.id,
       locked: false,
       merged: false,

--- a/pkgs/api/src/routes/v0/revisions/list.ts
+++ b/pkgs/api/src/routes/v0/revisions/list.ts
@@ -2,7 +2,7 @@ import { schemaId, schemaOrgId } from '@specfy/core';
 import type { Pagination } from '@specfy/core';
 import type { Prisma } from '@specfy/db';
 import { prisma } from '@specfy/db';
-import { toApiRevision } from '@specfy/models';
+import { toApiRevisionList } from '@specfy/models';
 import type { ListRevisions } from '@specfy/models';
 import type { FastifyPluginCallback, FastifyRequest } from 'fastify';
 import { z } from 'zod';
@@ -95,7 +95,7 @@ const fn: FastifyPluginCallback = (fastify, _, done) => {
 
     return res.status(200).send({
       data: list.map((rev) => {
-        return toApiRevision(rev);
+        return toApiRevisionList(rev);
       }),
       pagination,
     });

--- a/pkgs/app/src/api/revisions.ts
+++ b/pkgs/app/src/api/revisions.ts
@@ -96,6 +96,7 @@ export function useGetRevision({
   revision_id,
 }: GetRevision['QP']) {
   return useQuery({
+    enabled: Boolean(revision_id),
     queryKey: ['getRevision', org_id, project_id, revision_id],
     queryFn: async (): Promise<GetRevision['Success']> => {
       const { json, res } = await fetchApi<GetRevision>(

--- a/pkgs/app/src/views/Project/Deploy/Show/index.module.scss
+++ b/pkgs/app/src/views/Project/Deploy/Show/index.module.scss
@@ -8,10 +8,11 @@
 }
 
 .states {
-  padding: 0 var(--spc-6xl) var(--spc-6xl) var(--spc-6xl);
+  padding: 0 var(--spc-6xl) var(--spc-3xl) var(--spc-6xl);
 }
 
 .block {
+  width: 100%;
   min-width: 200px;
 
   .label {

--- a/pkgs/app/src/views/Project/Deploy/Show/index.tsx
+++ b/pkgs/app/src/views/Project/Deploy/Show/index.tsx
@@ -4,7 +4,7 @@ import { Helmet } from 'react-helmet-async';
 import Skeleton from 'react-loading-skeleton';
 import { useParams } from 'react-router-dom';
 
-import { useGetDeploy } from '../../../../api';
+import { useGetDeploy, useGetRevision } from '../../../../api';
 import { AvatarAuto } from '../../../../components/AvatarAuto';
 import { Banner } from '../../../../components/Banner';
 import { CodeHighlighter } from '../../../../components/CodeHighlighter';
@@ -14,10 +14,12 @@ import { StatusTag } from '../../../../components/Job/StatusTag';
 import { NotFound } from '../../../../components/NotFound';
 import { Time } from '../../../../components/Time';
 import type { RouteJob, RouteProject } from '../../../../types/routes';
+import { Row } from '../../Revisions/List';
 
 import cls from './index.module.scss';
 
 import { titleSuffix } from '@/common/string';
+import { Subdued } from '@/components/Text';
 
 type LogLine = {
   level: 30;
@@ -43,6 +45,11 @@ export const ProjectDeploysShow: React.FC<{
     org_id: params.org_id,
     project_id: proj.id,
     job_id: more.job_id!,
+  });
+  const getRev = useGetRevision({
+    org_id: params.org_id,
+    project_id: proj.id,
+    revision_id: deploy?.revisionId as string,
   });
 
   useEffect(() => {
@@ -156,6 +163,17 @@ export const ProjectDeploysShow: React.FC<{
               <AvatarAuto user={deploy.user} size="s" />
               {deploy.user.name}
             </Flex>
+          </div>
+        </Flex>
+        <Flex gap="l" className={cls.states}>
+          <div className={cls.block}>
+            <div className={cls.label}>Revision</div>
+
+            {getRev.data ? (
+              <Row item={getRev.data.data} />
+            ) : (
+              <Subdued>No revision created</Subdued>
+            )}
           </div>
         </Flex>
         {deploy.status === 'failed' && deploy.reason && (

--- a/pkgs/app/src/views/Project/Revisions/List/index.module.scss
+++ b/pkgs/app/src/views/Project/Revisions/List/index.module.scss
@@ -20,18 +20,18 @@
 .row {
   padding: var(--spc-l) var(--spc-6xl) var(--spc-xl) var(--spc-6xl);
   border-bottom: 1px solid var(--border1);
+}
 
-  .title {
-    font-weight: 500;
-  }
+.title {
+  font-weight: 500;
+}
 
-  .typeId {
-    font-weight: 300;
-    color: var(--text2);
-  }
+.typeId {
+  font-weight: 300;
+  color: var(--text2);
+}
 
-  .info {
-    font-size: var(--font-s);
-    color: var(--text2)
-  }
+.info {
+  font-size: var(--font-s);
+  color: var(--text2)
 }

--- a/pkgs/app/src/views/Project/Revisions/List/index.tsx
+++ b/pkgs/app/src/views/Project/Revisions/List/index.tsx
@@ -1,4 +1,8 @@
-import type { ApiProject, ListRevisions } from '@specfy/models';
+import type {
+  ApiProject,
+  ApiRevisionList,
+  ListRevisions,
+} from '@specfy/models';
 import {
   IconChevronRight,
   IconCircleXFilled,
@@ -36,40 +40,39 @@ const options: SelectOption[] = [
   { value: 'all', label: 'All' },
 ];
 
-const Row: React.FC<{
-  item: ListRevisions['Success']['data'][0];
-  params: RouteProject;
-}> = ({ item, params }) => {
-  const link = `/${params.org_id}/${params.project_slug}/revisions/${item.id}`;
-
+export const Row: React.FC<{
+  item: ApiRevisionList;
+}> = ({ item }) => {
+  const authors = item.authors.length > 0 ? item.authors : null;
   return (
-    <Flex className={cls.row} justify="space-between" align="center">
+    <Flex justify="space-between" align="center">
       <div>
         <Flex align="center" gap="l">
           <div className={cls.title}>
-            <Link to={link} relative="path">
+            <Link to={item.url} relative="path">
               {item.name}
             </Link>
           </div>
         </Flex>
         <Flex className={cls.info} gap="m">
-          <Time time={item.updatedAt} />·{' '}
-          {item.authors.length > 1 && (
-            <AvatarGroup>
-              {item.authors.map((user) => {
-                return <AvatarAuto key={user.id} user={user} size="s" />;
-              })}
-            </AvatarGroup>
-          )}
-          {item.authors.length > 0 && item.authors.length < 1 && (
-            <Flex gap="m">
-              <AvatarAuto
-                key={item.authors[0].id}
-                user={item.authors[0]}
-                size="s"
-              />
-              {item.authors[0].name}
-            </Flex>
+          <Time time={item.updatedAt} />
+          {authors && (
+            <>
+              ·{' '}
+              {authors.length > 1 && (
+                <AvatarGroup>
+                  {authors.map((user) => {
+                    return <AvatarAuto key={user.id} user={user} size="s" />;
+                  })}
+                </AvatarGroup>
+              )}
+              {authors.length > 0 && authors.length < 1 && (
+                <Flex gap="m">
+                  <AvatarAuto key={authors[0].id} user={authors[0]} size="s" />
+                  {authors[0].name}
+                </Flex>
+              )}
+            </>
           )}
         </Flex>
       </div>
@@ -80,7 +83,7 @@ const Row: React.FC<{
           merged={item.merged}
         />
 
-        <Link to={link} relative="path">
+        <Link to={item.url} relative="path">
           <IconChevronRight />
         </Link>
       </Flex>
@@ -191,7 +194,11 @@ export const ProjectRevisionsList: React.FC<{
         {list && (
           <div className={cls.list}>
             {list.data.map((item) => {
-              return <Row item={item} params={params} key={item.id} />;
+              return (
+                <div className={cls.row} key={item.id}>
+                  <Row item={item} />
+                </div>
+              );
             })}
           </div>
         )}

--- a/pkgs/db/prisma/migrations/20230926135458_add_jobid_to_revisions/migration.sql
+++ b/pkgs/db/prisma/migrations/20230926135458_add_jobid_to_revisions/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Revisions" ADD COLUMN     "jobId" VARCHAR(15);
+
+-- AddForeignKey
+ALTER TABLE "Revisions" ADD CONSTRAINT "Revisions_jobId_fkey" FOREIGN KEY ("jobId") REFERENCES "Jobs"("id") ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/pkgs/db/prisma/schema.prisma
+++ b/pkgs/db/prisma/schema.prisma
@@ -243,10 +243,12 @@ model Jobs {
   finishedAt DateTime? @db.Timestamp(3)
   updatedAt  DateTime  @updatedAt
 
-  Org     Orgs      @relation(fields: [orgId], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  Project Projects? @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  User    Users?    @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  Log     Logs?     @relation(fields: [logsId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  Org       Orgs        @relation(fields: [orgId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  Project   Projects?   @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  User      Users?      @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  Log       Logs?       @relation(fields: [logsId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  // Revisions Revisions[]
+  Revisions Revisions[]
 
   // FIXME:  https://github.com/prisma/prisma/issues/6974
   // SELECT WHERE type ORDER BY createdAt
@@ -406,6 +408,7 @@ model Revisions {
   id          String    @id @db.VarChar(15)
   orgId       String    @db.VarChar(36)
   projectId   String    @db.VarChar(15)
+  jobId       String?   @db.VarChar(15)
   name        String    @db.VarChar(75)
   /// [PrismaProseMirror]
   description Json      @db.Json
@@ -424,6 +427,7 @@ model Revisions {
 
   Org     Orgs     @relation(fields: [orgId], references: [id], onDelete: Cascade, onUpdate: NoAction)
   Project Projects @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  Jobs    Jobs?    @relation(fields: [jobId], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
   TypeHasUsers TypeHasUsers[]
   Reviews      Reviews[]

--- a/pkgs/github-sync/src/sync.ts
+++ b/pkgs/github-sync/src/sync.ts
@@ -43,6 +43,9 @@ export interface SyncOptions {
   autoLayout: boolean;
   hostname?: string;
   logger?: Logger;
+
+  // Internal
+  jobId?: string | undefined;
 }
 
 export class ErrorSync extends Error {
@@ -63,6 +66,7 @@ export async function sync({
   stackEnabled,
   stackPath,
   autoLayout,
+  jobId,
   hostname = 'https://api.specfy.io',
   logger = defaultLogger,
 }: SyncOptions) {
@@ -162,6 +166,7 @@ export async function sync({
     autoLayout,
     baseUrl,
     root,
+    jobId,
   });
 
   const resUp = await upload({ body, token, baseUrl, logger });

--- a/pkgs/github-sync/src/upload/index.ts
+++ b/pkgs/github-sync/src/upload/index.ts
@@ -22,17 +22,20 @@ export function prepBody({
   stack,
   autoLayout,
   root,
+  jobId,
 }: Omit<Params, 'token'> & {
   docs: TransformedFile[];
   root: string;
   stack?: Payload | null;
   autoLayout?: boolean | null;
+  jobId?: string | undefined;
 }): PostUploadRevision['Body'] {
   const now = new Date();
   const date = now.toISOString().split('T')[0];
   return {
     orgId,
     projectId,
+    jobId,
     name: `${title} ${date}`,
     description: { content: [], type: 'doc' },
     source: 'github',

--- a/pkgs/github/src/jobs/deploy.ts
+++ b/pkgs/github/src/jobs/deploy.ts
@@ -147,6 +147,7 @@ export class JobDeploy extends Job {
       await sync({
         orgId: job.orgId,
         projectId: job.projectId!,
+        jobId: job.id,
         token: key.id,
         root: this.folderName,
         stackEnabled: projConfig.stack.enabled,

--- a/pkgs/models/src/fastify.d.ts
+++ b/pkgs/models/src/fastify.d.ts
@@ -9,7 +9,7 @@ import type {
 import type { RouteGenericInterface } from 'fastify/types/route';
 
 import type { InvitationsWithOrgAndUser } from './invitations';
-import type { JobWithUser } from './jobs';
+import type { JobWithUserAndRevision } from './jobs';
 import type { PermsWithOrg } from './perms';
 import type { RevisionWithProject } from './revisions';
 
@@ -35,7 +35,7 @@ declare module 'fastify' {
     org?: Orgs;
     invitation?: InvitationsWithOrgAndUser;
     flow?: Flows;
-    job?: JobWithUser;
+    job?: JobWithUserAndRevision;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/pkgs/models/src/jobs/formatter.ts
+++ b/pkgs/models/src/jobs/formatter.ts
@@ -1,7 +1,7 @@
 import { toApiUser } from '../users/formatter.js';
 
 import type { ApiJob, ApiJobList } from './types.api.js';
-import type { JobWithUser } from './types.js';
+import type { JobWithUser, JobWithUserAndRevision } from './types.js';
 
 export function toApiJobList(job: JobWithUser): ApiJobList {
   return {
@@ -20,9 +20,10 @@ export function toApiJobList(job: JobWithUser): ApiJobList {
     user: toApiUser(job.User!),
   };
 }
-export function toApiJob(job: JobWithUser, logs: string): ApiJob {
+export function toApiJob(job: JobWithUserAndRevision, logs: string): ApiJob {
   return {
     ...toApiJobList(job),
+    revisionId: job.Revisions.length > 0 ? job.Revisions[0].id : null,
     logs,
   };
 }

--- a/pkgs/models/src/jobs/types.api.ts
+++ b/pkgs/models/src/jobs/types.api.ts
@@ -17,7 +17,10 @@ type ApiJobBase = Pick<
   user: ApiUser;
 };
 export type ApiJobList = ApiJobBase;
-export type ApiJob = ApiJobBase & { logs: string };
+export type ApiJob = ApiJobBase & {
+  logs: string;
+  revisionId: string | null;
+};
 
 // ------ GET /
 export type ListJobs = Res<{

--- a/pkgs/models/src/jobs/types.ts
+++ b/pkgs/models/src/jobs/types.ts
@@ -47,3 +47,10 @@ export type JobReason = JobMark;
 export type JobWithUser = Prisma.JobsGetPayload<{
   include: { User: true };
 }>;
+
+export type JobWithUserAndRevision = Prisma.JobsGetPayload<{
+  include: {
+    User: true;
+    Revisions: { select: { id: true } };
+  };
+}>;

--- a/pkgs/models/src/prosemirror/markdownParser.ts
+++ b/pkgs/models/src/prosemirror/markdownParser.ts
@@ -10,7 +10,7 @@ import {
   type BlockText,
   type Blocks,
 } from '../documents/index.js';
-import type { PostUploadRevision } from '../revisions/types.api.js';
+import type { PostUploadRevision, UploadBlob } from '../revisions/types.api.js';
 
 import {
   attrName,
@@ -36,17 +36,14 @@ export class DocumentsParser {
   parse(): ParsedUpload[] {
     const blobs = this.blobs;
 
-    if (blobs.length <= 0) {
+    if (!blobs || blobs.length <= 0) {
       return [];
     }
 
     const copy = [...blobs];
 
     // Build folder hierarchy
-    const folders = new Map<
-      string,
-      PostUploadRevision['Body']['blobs'][0] | false
-    >();
+    const folders = new Map<string, UploadBlob | false>();
     for (const blob of blobs) {
       if (folders.has(blob.path)) {
         const defined = folders.get(blob.path);

--- a/pkgs/models/src/revisions/formatter.ts
+++ b/pkgs/models/src/revisions/formatter.ts
@@ -1,17 +1,16 @@
 import { envs } from '@specfy/core';
 
-import type { ApiRevision } from '../revisions';
+import type { ApiRevision, ApiRevisionList } from '../revisions';
 import { toApiUser } from '../users/formatter.js';
 
 import type { RevisionWithProject } from './types.js';
 
-export function toApiRevision(rev: RevisionWithProject): ApiRevision {
+export function toApiRevisionList(rev: RevisionWithProject): ApiRevisionList {
   return {
     id: rev.id,
     orgId: rev.orgId,
     projectId: rev.projectId,
     name: rev.name,
-    description: rev.description,
     locked: rev.locked,
     merged: rev.merged,
     status: rev.status,
@@ -24,5 +23,13 @@ export function toApiRevision(rev: RevisionWithProject): ApiRevision {
     updatedAt: rev.updatedAt.toISOString(),
     mergedAt: rev.mergedAt ? rev.mergedAt.toISOString() : null,
     closedAt: rev.closedAt ? rev.closedAt.toISOString() : null,
+  };
+}
+
+export function toApiRevision(rev: RevisionWithProject): ApiRevision {
+  return {
+    ...toApiRevisionList(rev),
+    description: rev.description,
+    stack: rev.stack,
   };
 }

--- a/pkgs/models/src/revisions/types.api.ts
+++ b/pkgs/models/src/revisions/types.api.ts
@@ -20,10 +20,11 @@ import type { ApiUser } from '../users/types.api.js';
 import type { DocsToBlobs } from './helpers.upload.js';
 import type { DBRevision } from './types.js';
 
-export type ApiRevision = Omit<DBRevision, 'stack'> & {
-  authors: ApiUser[];
-  url: string;
-};
+type ApiRevisionBase = { authors: ApiUser[]; url: string };
+export type ApiRevisionList = Omit<DBRevision, 'stack' | 'description'> &
+  ApiRevisionBase;
+export type ApiRevision = DBRevision & ApiRevisionBase;
+
 export interface ParamsRevision {
   revision_id: string;
 }
@@ -37,7 +38,7 @@ export type ListRevisions = Res<{
     search?: string;
   };
   Success: {
-    data: ApiRevision[];
+    data: ApiRevisionList[];
     pagination: Pagination;
   };
 }>;
@@ -67,12 +68,14 @@ export type CreateRevisionError = {
     reason: 'no_diff';
   };
 };
+export type UploadBlob = { path: string; content: string };
 export type PostUploadRevision = Res<{
   Body: Pick<ApiRevision, 'description' | 'name' | 'orgId' | 'projectId'> & {
     source: string;
-    blobs: Array<{ path: string; content: string }>;
+    blobs: UploadBlob[] | null;
     stack: AnalyserJson | null;
     autoLayout?: boolean;
+    jobId?: string | undefined;
   };
   Error: CreateRevisionError;
   Success: {


### PR DESCRIPTION
- Store the `jobId` inside `Revisions 
This allow to create a strong link between both and using this information to get more data after the fact. For debugging and UI reason. 

- GET job/id now returns the linked revision

*null or empty*
<img width="923" alt="Screenshot 2023-09-26 at 17 08 06" src="https://github.com/specfy/specfy/assets/1637651/5e6fce14-1c1f-45e5-bb9b-828647fbaeaf">


*With on Revision*
<img width="906" alt="Screenshot 2023-09-26 at 17 09 12" src="https://github.com/specfy/specfy/assets/1637651/c442e7dd-837b-4a5c-abaf-88fdeda1681b">
