### PR TITLE
fix: remove deprecated column for source in Projects

### DIFF
--- a/pkgs/api/src/routes/v0/demo/createDemo.ts
+++ b/pkgs/api/src/routes/v0/demo/createDemo.ts
@@ -6,7 +6,6 @@ import {
   createComponent,
   recomputeOrgGraph,
   createProject,
-  getDefaultConfig,
 } from '@specfy/models';
 
 import type { Orgs, Prisma, Users } from '@specfy/db';
@@ -38,7 +37,6 @@ export async function createDemo(
           },
         ],
       },
-      config: getDefaultConfig(),
     },
     user,
     tx,
@@ -145,7 +143,6 @@ export async function createDemo(
         { title: 'GitHub', url: 'https://github.com/specfy' },
         { title: 'Discord', url: 'https://discord.gg/96cDXvT8NV' },
       ],
-      config: getDefaultConfig(),
     },
     user,
     tx,
@@ -173,7 +170,6 @@ export async function createDemo(
           },
         ],
       },
-      config: getDefaultConfig(),
     },
     user,
     tx,

--- a/pkgs/api/src/routes/v0/projects/create.ts
+++ b/pkgs/api/src/routes/v0/projects/create.ts
@@ -7,7 +7,6 @@ import {
   getOrgFromRequest,
   forbiddenProjectSlug,
   schemaProject,
-  getDefaultConfig,
 } from '@specfy/models';
 import z from 'zod';
 
@@ -75,12 +74,8 @@ const fn: FastifyPluginCallback = (fastify, _, done) => {
             orgId: data.orgId,
             name: data.name,
             slug,
-            description: {
-              type: 'doc',
-              content: [],
-            },
+            description: { type: 'doc', content: [] },
             links: [],
-            config: getDefaultConfig(),
           },
           user: req.me!,
           tx,

--- a/pkgs/api/src/routes/v0/projects/get.test.ts
+++ b/pkgs/api/src/routes/v0/projects/get.test.ts
@@ -54,18 +54,6 @@ describe('GET /projects/:project_id', () => {
       createdAt: expect.toBeIsoDate(),
       updatedAt: expect.toBeIsoDate(),
       links: [],
-      githubRepository: null,
-      config: {
-        branch: 'main',
-        documentation: {
-          enabled: true,
-          path: '/',
-        },
-        stack: {
-          enabled: true,
-          path: '/',
-        },
-      },
     });
   });
 

--- a/pkgs/api/src/routes/v0/projects/list.test.ts
+++ b/pkgs/api/src/routes/v0/projects/list.test.ts
@@ -53,7 +53,6 @@ describe('GET /projects', () => {
         name: project.name,
         orgId: project.orgId,
         slug: project.slug,
-        githubRepository: null,
         users: 1,
         createdAt: expect.toBeIsoDate(),
         updatedAt: expect.toBeIsoDate(),

--- a/pkgs/api/src/routes/v0/projects/update.test.ts
+++ b/pkgs/api/src/routes/v0/projects/update.test.ts
@@ -130,27 +130,4 @@ describe('PUT /projects/:project_id', () => {
     isValidationError(res.json);
     expect(res.statusCode).toBe(400);
   });
-
-  it('should update config', async () => {
-    const { token, org, project } = await seedWithProject();
-
-    const config = {
-      branch: 'top',
-      stack: { enabled: false, path: '/tip/top' },
-      documentation: { enabled: false, path: '/foobar' },
-    };
-    const res = await t.fetch.put(`/0/projects/${project.id}`, {
-      token,
-      Querystring: { org_id: org.id },
-      Body: {
-        config,
-      },
-    });
-
-    isSuccess(res.json);
-    expect(res.statusCode).toBe(200);
-    expect(res.json.data.config).toStrictEqual({
-      ...config,
-    });
-  });
 });

--- a/pkgs/api/src/routes/v0/projects/update.ts
+++ b/pkgs/api/src/routes/v0/projects/update.ts
@@ -36,10 +36,9 @@ function BodyVal(req: FastifyRequest) {
           message: `This slug is already used`,
         });
       }),
-      config: schemaProject.shape.config,
     })
     .strict()
-    .partial({ name: true, slug: true, config: true });
+    .partial({ name: true, slug: true });
 }
 
 const fn: FastifyPluginCallback = (fastify, _, done) => {
@@ -69,15 +68,6 @@ const fn: FastifyPluginCallback = (fastify, _, done) => {
           });
 
           await recomputeOrgGraph({ orgId: tmp.orgId, tx });
-
-          return tmp;
-        });
-      } else if (data.config) {
-        project = await prisma.$transaction(async (tx) => {
-          const tmp = await tx.projects.update({
-            data: { config: data.config! },
-            where: { id: project.id },
-          });
 
           return tmp;
         });

--- a/pkgs/api/src/routes/v0/sources/create.ts
+++ b/pkgs/api/src/routes/v0/sources/create.ts
@@ -13,7 +13,7 @@ import {
   createGitHubActivity,
   createJobDeploy,
   getOrgFromRequest,
-  schemaProject,
+  schemaGitHubSettings,
 } from '@specfy/models';
 import { z } from 'zod';
 
@@ -38,7 +38,7 @@ function QueryVal(req: FastifyRequest) {
       type: z.literal('github'),
       name: z.string().max(50),
       identifier: z.string().max(500).regex(repoRegex),
-      settings: schemaProject.shape.config,
+      settings: schemaGitHubSettings,
     })
     .strict()
     .partial({ name: true })
@@ -100,13 +100,8 @@ const fn: FastifyPluginCallback = (fastify, _, done) => {
           );
         }
 
-        // Double write until deprecation
         await tx.projects.update({
-          data: {
-            links,
-            githubRepository: body.identifier,
-            config: body.settings,
-          },
+          data: { links },
           where: { id: body.projectId },
         });
 

--- a/pkgs/api/src/routes/v0/sources/remove.ts
+++ b/pkgs/api/src/routes/v0/sources/remove.ts
@@ -25,9 +25,8 @@ const fn: FastifyPluginCallback = (fastify, _, done) => {
           (link) => link.title === 'GitHub' && link.url === url
         );
 
-        // Double write until deprecation
         await tx.projects.update({
-          data: { links, githubRepository: null },
+          data: { links },
           where: { id: source.projectId },
         });
 

--- a/pkgs/api/src/routes/v0/sources/update.ts
+++ b/pkgs/api/src/routes/v0/sources/update.ts
@@ -1,5 +1,5 @@
 import { prisma } from '@specfy/db';
-import { schemaProject } from '@specfy/models';
+import { schemaGitHubSettings } from '@specfy/models';
 import { z } from 'zod';
 
 import type { PutSource } from '@specfy/models';
@@ -13,7 +13,7 @@ function QueryVal() {
   return z
     .object({
       name: z.string().max(50),
-      settings: schemaProject.shape.config,
+      settings: schemaGitHubSettings,
     })
     .strict();
 }
@@ -30,12 +30,6 @@ const fn: FastifyPluginCallback = (fastify, _, done) => {
 
       const source = req.source!;
       const data: PutSource['Body'] = val.data;
-
-      // Double write until deprecation
-      await prisma.projects.update({
-        data: { config: data.settings },
-        where: { id: source.projectId },
-      });
 
       const up = await prisma.sources.update({
         data: {

--- a/pkgs/api/src/test/seed/e2e.ts
+++ b/pkgs/api/src/test/seed/e2e.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { dirname, envs, l } from '@specfy/core';
 import { prisma } from '@specfy/db';
 import { sync } from '@specfy/github-sync';
-import { createProject } from '@specfy/models';
+import { createProject, getDefaultConfig } from '@specfy/models';
 import { getBlobProject } from '@specfy/models/src/projects/test.utils.js';
 
 import type { Orgs, Users } from '@specfy/db';
@@ -19,7 +19,7 @@ export async function seedE2E({ o1 }: { o1: Orgs }, users: Users[]) {
     where: { projectId: pE2E.id },
   });
 
-  const projConfig = pE2E.config;
+  const projConfig = getDefaultConfig();
   const folderName = path.join(dirname, '../../');
   await sync({
     orgId: o1.id,

--- a/pkgs/db/prisma/migrations/20230928131640_remove_column_github_from_projects/migration.sql
+++ b/pkgs/db/prisma/migrations/20230928131640_remove_column_github_from_projects/migration.sql
@@ -1,0 +1,27 @@
+/*
+ Warnings:
+
+ - You are about to drop the column `config` on the `Projects` table. All the data in the column will be lost.
+ - You are about to drop the column `githubRepository` on the `Projects` table. All the data in the column will be lost.
+ */
+-- AlterTable
+ALTER TABLE "Projects"
+  DROP COLUMN "config",
+  DROP COLUMN "githubRepository";
+
+-- Backport old blobs to avoid any conflict
+UPDATE
+  "Blobs"
+SET
+  CURRENT = sub.next
+FROM (
+  SELECT
+    id,
+    CURRENT::jsonb - 'githubRepository' - 'config' AS next
+  FROM
+    "Blobs"
+  WHERE
+    type = 'project') AS sub
+WHERE
+  "Blobs".id = sub.id;
+

--- a/pkgs/db/prisma/schema.prisma
+++ b/pkgs/db/prisma/schema.prisma
@@ -358,20 +358,18 @@ model Policies {
 }
 
 model Projects {
-  id               String   @id @db.VarChar(15)
-  orgId            String   @db.VarChar(36)
-  blobId           String?  @db.VarChar(15)
-  name             String   @db.VarChar(36)
-  slug             String   @db.VarChar(100)
+  id          String  @id @db.VarChar(15)
+  orgId       String  @db.VarChar(36)
+  blobId      String? @db.VarChar(15)
+  name        String  @db.VarChar(36)
+  slug        String  @db.VarChar(100)
   /// [PrismaProseMirror]
-  description      Json     @db.Json
+  description Json    @db.Json
   /// [PrismaProjectsLinks]
-  links            Json     @db.Json
-  githubRepository String?
-  /// [PrismaProjectsConfig]
-  config           Json     @db.Json
-  createdAt        DateTime @default(now()) @db.Timestamp(3)
-  updatedAt        DateTime @updatedAt
+  links       Json    @db.Json
+
+  createdAt DateTime @default(now()) @db.Timestamp(3)
+  updatedAt DateTime @updatedAt
 
   Org  Orgs   @relation(fields: [orgId], references: [id], onDelete: Cascade, onUpdate: NoAction)
   Blob Blobs? @relation(fields: [blobId], references: [id], name: "blob", onDelete: Cascade, onUpdate: NoAction)

--- a/pkgs/models/src/github/model.ts
+++ b/pkgs/models/src/github/model.ts
@@ -14,8 +14,8 @@ export async function createGitHubActivity({
 }: {
   user: Users;
   action: ActionGitHub;
-  org: Orgs;
-  project?: Projects;
+  org: Pick<Orgs, 'id'>;
+  project?: Pick<Projects, 'id'>;
   tx: Prisma.TransactionClient;
   activityGroupId?: string | null;
 }): Promise<Activities> {

--- a/pkgs/models/src/prisma.d.ts
+++ b/pkgs/models/src/prisma.d.ts
@@ -52,8 +52,6 @@ declare global {
 
     // Projects
     type PrismaProjectsLinks = DBProject['links'];
-    type PrismaProjectsConfig = DBProject['config'];
-
     // Revisions
     type PrismaRevisionsBlobs = DBRevision['blobs'];
     type PrismaRevisionsStatus = DBRevision['status'];

--- a/pkgs/models/src/projects/formatter.ts
+++ b/pkgs/models/src/projects/formatter.ts
@@ -11,8 +11,6 @@ export function toApiProject(proj: Projects): ApiProject {
     name: proj.name,
     slug: proj.slug,
     links: proj.links,
-    config: proj.config,
-    githubRepository: proj.githubRepository,
     createdAt: proj.createdAt.toISOString(),
     updatedAt: proj.updatedAt.toISOString(),
   };
@@ -26,7 +24,6 @@ export function toApiProjectList(
     orgId: proj.orgId,
     name: proj.name,
     slug: proj.slug,
-    githubRepository: proj.githubRepository,
     createdAt: proj.createdAt.toISOString(),
     updatedAt: proj.updatedAt.toISOString(),
     users: proj._count.Perms,

--- a/pkgs/models/src/projects/model.ts
+++ b/pkgs/models/src/projects/model.ts
@@ -4,7 +4,6 @@ import type { Projects, Prisma, Activities, Users } from '@specfy/db';
 
 import { createKey } from '../keys/model.js';
 
-import type { DBProject } from './types.js';
 import type { ActionProject } from '../activities/types.js';
 
 export async function createProjectBlob({
@@ -114,18 +113,4 @@ export async function createProjectActivity({
       createdAt: new Date(),
     },
   });
-}
-
-export function getDefaultConfig(): DBProject['config'] {
-  return {
-    branch: 'main',
-    documentation: {
-      enabled: true,
-      path: '/',
-    },
-    stack: {
-      enabled: true,
-      path: '/',
-    },
-  };
 }

--- a/pkgs/models/src/projects/schema.ts
+++ b/pkgs/models/src/projects/schema.ts
@@ -17,29 +17,11 @@ export const schemaProject = z
     links: z.array(
       z
         .object({
-          title: z.string().max(20),
+          title: z.string().max(30),
           url: z.string().url(),
         })
         .strict()
     ),
-    githubRepository: z.string().nullable(),
-    config: z
-      .object({
-        branch: z.string().max(255),
-        documentation: z
-          .object({
-            enabled: z.boolean(),
-            path: z.string().max(255),
-          })
-          .strict(),
-        stack: z
-          .object({
-            enabled: z.boolean(),
-            path: z.string().max(255),
-          })
-          .strict(),
-      })
-      .strict(),
     createdAt: z.string().datetime(),
     updatedAt: z.string().datetime(),
   })

--- a/pkgs/models/src/projects/test.utils.ts
+++ b/pkgs/models/src/projects/test.utils.ts
@@ -2,8 +2,6 @@ import { nanoid, slugify } from '@specfy/core';
 
 import type { Orgs } from '@specfy/db';
 
-import { getDefaultConfig } from './model.js';
-
 import type { DBProject } from './types.js';
 import type { ApiBlobProject } from '../blobs/types.api.js';
 
@@ -16,9 +14,7 @@ export function getBlobProject(org: Pick<Orgs, 'id'>): DBProject {
     name,
     slug: slugify(name),
     blobId: null,
-    config: getDefaultConfig(),
     description: { type: 'doc', content: [] },
-    githubRepository: null,
     links: [],
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),

--- a/pkgs/models/src/projects/types.api.ts
+++ b/pkgs/models/src/projects/types.api.ts
@@ -50,7 +50,6 @@ export type PutProject = Res<{
   Body: {
     name?: string | undefined;
     slug?: string | undefined;
-    config?: ApiProject['config'] | undefined;
   };
   Success: { data: ApiProject };
 }>;

--- a/pkgs/models/src/projects/types.ts
+++ b/pkgs/models/src/projects/types.ts
@@ -1,6 +1,4 @@
 import type { BlockLevelZero } from '../documents';
-import type { SyncConfig } from '../sync.js';
-import type { RequiredDeep } from 'type-fest';
 
 export interface DBProject {
   id: string;
@@ -10,10 +8,6 @@ export interface DBProject {
   name: string;
   description: BlockLevelZero;
   links: DBProjectLink[];
-
-  githubRepository: string | null;
-  config: RequiredDeep<Omit<SyncConfig, 'orgId' | 'projectId'>>;
-
   createdAt: string;
   updatedAt: string;
 }

--- a/pkgs/models/src/revisions/constants.ts
+++ b/pkgs/models/src/revisions/constants.ts
@@ -23,12 +23,7 @@ const IGNORED_KEYS_MERGE = [
   'orgId',
 ] as const;
 
-export const IGNORED_PROJECT_KEYS_CONST = [
-  ...IGNORED_KEYS,
-  'name',
-  'githubRepository',
-  'config',
-] as const;
+export const IGNORED_PROJECT_KEYS_CONST = [...IGNORED_KEYS, 'name'] as const;
 export const IGNORED_PROJECT_KEYS: ReadonlyArray<
   keyof NonNullable<ApiBlobProject['current']>
 > = IGNORED_PROJECT_KEYS_CONST;

--- a/pkgs/models/src/sources/index.ts
+++ b/pkgs/models/src/sources/index.ts
@@ -1,2 +1,4 @@
+export * from './model.js';
+export * from './schema.js';
 export * from './types.api.js';
 export * from './types.js';

--- a/pkgs/models/src/sources/model.ts
+++ b/pkgs/models/src/sources/model.ts
@@ -1,0 +1,15 @@
+import type { SourceSettingsGithub } from './types.js';
+
+export function getDefaultConfig(): SourceSettingsGithub {
+  return {
+    branch: 'main',
+    documentation: {
+      enabled: true,
+      path: '/',
+    },
+    stack: {
+      enabled: true,
+      path: '/',
+    },
+  };
+}

--- a/pkgs/models/src/sources/schema.ts
+++ b/pkgs/models/src/sources/schema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const schemaGitHubSettings = z
+  .object({
+    branch: z.string().max(255),
+    documentation: z
+      .object({
+        enabled: z.boolean(),
+        path: z.string().max(255),
+      })
+      .strict(),
+    stack: z
+      .object({
+        enabled: z.boolean(),
+        path: z.string().max(255),
+      })
+      .strict(),
+  })
+  .strict();


### PR DESCRIPTION
Follow up of #246 

Old blobs are cleaned to avoid any conflict in the future, at the expanse of effectively loosing the data. 
I could find a better alternatives like ignoring fields at merge time (nb: those one were already ignored).